### PR TITLE
Support to fetch vSphere and k8s Version from k8s cluster and fetch corresponding Deployment Yamls

### DIFF
--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -38,8 +38,9 @@ var sessionMU sync.Mutex
 // Session is a vSphere session with a configured Finder.
 type Session struct {
 	*govmomi.Client
-	Finder     *find.Finder
-	datacenter *object.Datacenter
+	Finder         *find.Finder
+	datacenter     *object.Datacenter
+	VsphereVersion string
 }
 
 // GetOrCreate gets a cached session or creates a new one if one does not
@@ -85,6 +86,7 @@ func GetOrCreate(
 	}
 	session.datacenter = dc
 	session.Finder.SetDatacenter(dc)
+	session.VsphereVersion = session.Client.ServiceContent.About.Version
 
 	// Cache the session.
 	sessionCache[sessionKey] = session


### PR DESCRIPTION
**This PR brings in the following support :**
1. Fetch vSphere and k8s version dynamically
2. Fetch CPI and CSI deployment yamls for corresponding vSphere and k8s version from the compatibility matrix
3. Unit tests for different cases of versions/yamls.

Ran the unit tests : 

```
?       github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator     [no test files]
?       github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/api/v1alpha1        [no test files]
ok      github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/controllers 11.409s coverage: 26.8% of statements
ok      github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/client  11.063s coverage: 60.0% of statements
?       github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/context [no test files]
ok      github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/drivers/cpi     0.388s  coverage: 88.0% of statements
ok      github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/drivers/csi     0.748s  coverage: 77.1% of statements
?       github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/models  [no test files]
ok      github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/session 0.746s  coverage: 61.2% of statements
```


```
kubectl get pods -A

NAMESPACE           NAME                                     READY   STATUS    RESTARTS   AGE
kube-system         vsphere-cloud-controller-manager-dfl97   1/1     Running   0          3m16s
kube-system         vsphere-csi-controller-55f949b89-fvvjv   6/6     Running   0          2m59s
kube-system         vsphere-csi-node-f79nl                   3/3     Running   0          2m58s
kube-system         vsphere-csi-node-vn57x                   3/3     Running   0          2m59s
vmware-system-vdo   vdo-controller-manager-d57b9684d-ggt6t   2/2     Running   0          3m42s

```
```

kubectl describe nodes | grep ProviderID
ProviderID:                   vsphere://423fa6d2-76c2-c6c0-cd3a-5e98ead5d42a
ProviderID:                   vsphere://423fd8bc-d5d4-c071-3055-52cae661ef83
```

```
kubectl get vdoconfig -A -o yaml
apiVersion: v1
items:
- apiVersion: vdo.vmware.com/v1alpha1
  kind: VDOConfig
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"vdo.vmware.com/v1alpha1","kind":"VDOConfig","metadata":{"annotations":{},"name":"vdoconfig-sample","namespace":"vmware-system-vdo"},"spec":{"cloudProvider":{"vsphereCloudConfigs":["vspherecloudconfig-sample"]},"storageProvider":{"vsphereCloudConfig":"vspherecloudconfig-sample"}}}
    creationTimestamp: "2021-09-01T21:19:55Z"
    generation: 1
    name: vdoconfig-sample
    namespace: vmware-system-vdo
    resourceVersion: "87264"
    uid: 4691f655-e76d-4518-8309-968f86c3d8eb
  spec:
    cloudProvider:
      vsphereCloudConfigs:
      - vspherecloudconfig-sample
    storageProvider:
      vsphereCloudConfig: vspherecloudconfig-sample
  status:
    cpi:
      'nodeStatus ':
        master01: ready
        worker01: ready
      phase: Configured
    csi:
      phase: Configuring
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""

```

```
kubectl describe pvc example-vanilla-block-pvc
Name:          example-vanilla-block-pvc
Namespace:     default
StorageClass:  k8s-default-storage
Status:        Bound
Volume:        pvc-f8f9fce8-ef58-4393-bfe0-56a03e662178
Labels:        <none>
Annotations:   pv.kubernetes.io/bind-completed: yes
               pv.kubernetes.io/bound-by-controller: yes
               volume.beta.kubernetes.io/storage-provisioner: csi.vsphere.vmware.com
Finalizers:    [kubernetes.io/pvc-protection]
Capacity:      2Gi
Access Modes:  RWO
VolumeMode:    Filesystem
Used By:       <none>
Events:
  Type    Reason                 Age   From                                                                                                Message
  ----    ------                 ----  ----                                                                                                -------
  Normal  ExternalProvisioning   66s   persistentvolume-controller                                                                         waiting for a volume to be created, either by external provisioner "csi.vsphere.vmware.com" or manually created by system administrator
  Normal  Provisioning           66s   csi.vsphere.vmware.com_vsphere-csi-controller-55f949b89-fvvjv_cf28ca96-ca83-4f96-ba5d-e6462c0e6a42  External provisioner is provisioning volume for claim "default/example-vanilla-block-pvc"
  Normal  ProvisioningSucceeded  62s   csi.vsphere.vmware.com_vsphere-csi-controller-55f949b89-fvvjv_cf28ca96-ca83-4f96-ba5d-e6462c0e6a42  Successfully provisioned volume pvc-f8f9fce8-ef58-4393-bfe0-56a03e662178


```

