### PR TITLE
Add implementation for getting CPI nodes and support for multi Datacenters

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -18,4 +18,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: vmware.com/vdo
-  newTag: "6861e79"
+  newTag: a2e334c

--- a/controllers/vdoconfig_controller.go
+++ b/controllers/vdoconfig_controller.go
@@ -19,6 +19,7 @@ package controllers
 import (
 	"context"
 	"fmt"
+	"github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/session"
 	"os"
 	"reflect"
 	"strconv"
@@ -53,7 +54,6 @@ import (
 
 const (
 	CLOUD_PROVIDER_INIT_TAINT_KEY = "node.cloudprovider.kubernetes.io/uninitialized"
-	TAINT_NOSCHEDULE_KEY          = "NoSchedule"
 	VDO_NODE_LABEL_KEY            = "vdo.vmware.com/vdoconfig"
 	VDO_NAMESPACE                 = "vmware-system-vdo"
 	CPI_DEPLOYMENT_NAME           = "vsphere-cloud-controller-manager"
@@ -75,6 +75,8 @@ type VDOConfigReconciler struct {
 	Scheme       *runtime.Scheme
 	ClientConfig *restclient.Config
 }
+
+var NodeAvailabilityMap = make(map[string]bool)
 
 // +kubebuilder:rbac:groups=vdo.vmware.com,resources=vdoconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=vdo.vmware.com,resources=vdoconfigs/status,verbs=get;update;patch
@@ -236,20 +238,6 @@ func (r *VDOConfigReconciler) reconcileCPIConfiguration(vdoctx vdocontext.VDOCon
 		return ctrl.Result{}, err
 	}
 
-	vdoctx.Logger.V(4).Info("reconciling node taint for CPI")
-	err = r.reconcileNodeTaint(vdoctx, clientset)
-	if err != nil {
-		r.updateCPIStatusForError(vdoctx, err, vdoConfig, "Error in reconcile of node taint for CPI configuration")
-		return ctrl.Result{}, err
-	}
-
-	vdoctx.Logger.V(4).Info("reconciling node label for CPI")
-	err = r.reconcileNodeLabel(vdoctx, req, clientset)
-	if err != nil {
-		r.updateCPIStatusForError(vdoctx, err, vdoConfig, "Error in reconcile of node label for CPI configuration")
-		return ctrl.Result{}, err
-	}
-
 	vdoctx.Logger.V(4).Info("reconciling deployment for CPI")
 	updateStatus, err := r.reconcileCPIDeployment(vdoctx, deploymentYamls)
 	if err != nil {
@@ -280,9 +268,16 @@ func (r *VDOConfigReconciler) reconcileCPIConfiguration(vdoctx vdocontext.VDOCon
 	}
 
 	vdoctx.Logger.Info("reconciling node providerID")
-	config, err := r.reconcileNodeProviderID(vdoctx, vdoConfig, clientset)
+	config, err, nodeList := r.reconcileNodeProviderID(vdoctx, vdoConfig, clientset, &vsphereCloudConfigItems)
 	if err != nil {
-		r.updateCPIStatusForError(vdoctx, err, vdoConfig, "Error in reconcile of Provider ID for CPI")
+		r.updateCPIStatusForError(vdoctx, err, vdoConfig, err.Error())
+		return ctrl.Result{}, err
+	}
+
+	vdoctx.Logger.V(4).Info("reconciling node label for CPI")
+	err = r.reconcileNodeLabel(vdoctx, req, clientset, nodeList)
+	if err != nil {
+		r.updateCPIStatusForError(vdoctx, err, vdoConfig, err.Error())
 		return ctrl.Result{}, err
 	}
 
@@ -609,51 +604,13 @@ func (r *VDOConfigReconciler) updateVdoConfigWithNodeStatus(ctx context.Context,
 	return nil
 }
 
-func (r *VDOConfigReconciler) reconcileNodeTaint(ctx context.Context, clientset *kubernetes.Clientset) error {
-	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return errors.Wrapf(err, "Unable to fetch list of nodes")
-	}
+func (r *VDOConfigReconciler) reconcileNodeLabel(ctx vdocontext.VDOContext, req ctrl.Request, clientset *kubernetes.Clientset, nodeList []v1.Node) error {
 
-nodeLoop:
-	for _, node := range nodes.Items {
-		for _, taint := range node.Spec.Taints {
-			if taint.Key == CLOUD_PROVIDER_INIT_TAINT_KEY {
-				continue nodeLoop
-			}
-		}
-
-		r.Logger.Info("adding taint", "name", CLOUD_PROVIDER_INIT_TAINT_KEY)
-
-		taint := v1.Taint{
-			Key:       CLOUD_PROVIDER_INIT_TAINT_KEY,
-			Value:     "true",
-			Effect:    TAINT_NOSCHEDULE_KEY,
-			TimeAdded: nil,
-		}
-
-		node.Spec.Taints = append(node.Spec.Taints, taint)
-
-		_, err := clientset.CoreV1().Nodes().Update(ctx, &node, metav1.UpdateOptions{})
-		if err != nil {
-			return errors.Wrapf(err, "Error when updating taint %s on node %s", CLOUD_PROVIDER_INIT_TAINT_KEY, node.Name)
-		}
-	}
-
-	return nil
-}
-
-func (r *VDOConfigReconciler) reconcileNodeLabel(ctx vdocontext.VDOContext, req ctrl.Request, clientset *kubernetes.Clientset) error {
-	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return errors.Wrapf(err, "Unable to fetch list of nodes")
-	}
-
-	for _, node := range nodes.Items {
+	for _, node := range nodeList {
 		if _, ok := node.Labels[VDO_NODE_LABEL_KEY]; !ok {
 			r.Logger.Info("adding node label", "name", VDO_NODE_LABEL_KEY)
 			node.Labels[VDO_NODE_LABEL_KEY] = req.Name
-			_, err = clientset.CoreV1().Nodes().Update(ctx, &node, metav1.UpdateOptions{})
+			_, err := clientset.CoreV1().Nodes().Update(ctx, &node, metav1.UpdateOptions{})
 			if err != nil {
 				return errors.Wrapf(err, "Unable to update label on node")
 			}
@@ -663,32 +620,70 @@ func (r *VDOConfigReconciler) reconcileNodeLabel(ctx vdocontext.VDOContext, req 
 	return nil
 }
 
-func (r *VDOConfigReconciler) reconcileNodeProviderID(ctx vdocontext.VDOContext, config *vdov1alpha1.VDOConfig, clientset *kubernetes.Clientset) (*vdov1alpha1.VDOConfig, error) {
+func (r *VDOConfigReconciler) reconcileNodeProviderID(ctx vdocontext.VDOContext, config *vdov1alpha1.VDOConfig, clientset *kubernetes.Clientset, vsphereCloudConfigs *[]vdov1alpha1.VsphereCloudConfig) (*vdov1alpha1.VDOConfig, error, []v1.Node) {
 	nodeStatus := make(map[string]vdov1alpha1.NodeStatus)
-	cpiStatus := vdov1alpha1.Configured
+	var NodeList []v1.Node
 
+	cpiStatus := vdov1alpha1.Configured
 	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return config, errors.Wrapf(err, "Unable to fetch list of nodes")
+		return config, errors.Wrapf(err, "Error reconciling the providerID for CPI, unable to fetch list of nodes"), NodeList
 	}
 
+nodeLoop:
 	for _, node := range nodes.Items {
 		if len(node.Spec.ProviderID) > 0 {
 			nodeStatus[node.Name] = vdov1alpha1.NodeStatusReady
-		} else {
-			nodeStatus[node.Name] = vdov1alpha1.NodeStatusPending
-			cpiStatus = vdov1alpha1.Configuring
+			NodeList = append(NodeList, node)
+			r.Logger.Info(fmt.Sprintf("Added %s node to NodeList", node.Name))
+			continue nodeLoop
 		}
+
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == CLOUD_PROVIDER_INIT_TAINT_KEY {
+
+				if val, ok := NodeAvailabilityMap[node.Name]; ok {
+					if val {
+						nodeStatus[node.Name] = vdov1alpha1.NodeStatusPending
+						cpiStatus = vdov1alpha1.Configuring
+						NodeList = append(NodeList, node)
+						r.Logger.Info(fmt.Sprintf("Added %s node to NodeList", node.Name))
+						continue nodeLoop
+					}
+				}
+
+				NodeAvailabilityMap[node.Name], err = r.checkNodeExistence(ctx, config, vsphereCloudConfigs, node)
+				if err != nil {
+					return config, errors.Wrapf(err, "Error reconciling the providerID for CPI"), NodeList
+				}
+
+				if val, ok := NodeAvailabilityMap[node.Name]; ok {
+					if val {
+						nodeStatus[node.Name] = vdov1alpha1.NodeStatusPending
+						cpiStatus = vdov1alpha1.Configuring
+						NodeList = append(NodeList, node)
+						r.Logger.Info(fmt.Sprintf("Added %s node to NodeList", node.Name))
+						continue nodeLoop
+					}
+				}
+
+				errorMsg := fmt.Sprintf(" Cloud Provider is not configured to manage the node %s. Please check your cloud Provider settings. ", node.Name)
+				r.updateCPIStatusForError(ctx, errors.New(errorMsg), config, errorMsg)
+				return config, errors.New(errorMsg), NodeList
+			}
+
+		}
+
 	}
 
 	if config.Status.CPIStatus.Phase != cpiStatus ||
 		!reflect.DeepEqual(config.Status.CPIStatus.NodeStatus, nodeStatus) {
 		config.Status.CPIStatus.NodeStatus = nodeStatus
 		config.Status.CPIStatus.Phase = cpiStatus
-		return config, nil
+		return config, nil, NodeList
 	}
 
-	return nil, nil
+	return nil, nil, NodeList
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -748,8 +743,7 @@ func (r *VDOConfigReconciler) reconcileCPISecret(ctx vdocontext.VDOContext, conf
 
 			err = r.Create(ctx, &cpiSecret)
 			if err != nil {
-				config.Status.CPIStatus.Phase = vdov1alpha1.Failed
-				config.Status.CPIStatus.StatusMsg = fmt.Sprintf("could not create cpi secret %s", cpiSecret.Name)
+				r.updateCPIStatusForError(ctx, err, config, fmt.Sprintf("could not create cpi secret %s", cpiSecret.Name))
 				return config, errors.Wrap(err, "error creating cpi secret")
 			}
 
@@ -757,9 +751,7 @@ func (r *VDOConfigReconciler) reconcileCPISecret(ctx vdocontext.VDOContext, conf
 			err = r.updateCPIPhase(ctx, config, vdov1alpha1.Configuring, "")
 			return config, err
 		}
-
-		config.Status.CPIStatus.StatusMsg = fmt.Sprintf("unable to fetch secret %s", cpiSecret.Name)
-		config.Status.CPIStatus.Phase = vdov1alpha1.Failed
+		r.updateCPIStatusForError(ctx, err, config, fmt.Sprintf("unable to fetch secret %s", cpiSecret.Name))
 		return config, err
 	}
 
@@ -771,8 +763,7 @@ func (r *VDOConfigReconciler) reconcileCPISecret(ctx vdocontext.VDOContext, conf
 		err = r.Update(ctx, &cpiSecret)
 		if err != nil {
 			ctx.Logger.Error(err, "error occurred when updating cpiSecret")
-			config.Status.CPIStatus.Phase = vdov1alpha1.Failed
-			config.Status.CPIStatus.StatusMsg = fmt.Sprintf("could not update cpi secret %s", cpiSecret.Name)
+			r.updateCPIStatusForError(ctx, err, config, fmt.Sprintf("could not update cpi secret %s", cpiSecret.Name))
 			return config, err
 		}
 		err = r.updateCPIPhase(ctx, config, vdov1alpha1.Configuring, "")
@@ -791,9 +782,7 @@ func (r *VDOConfigReconciler) reconcileConfigMap(ctx vdocontext.VDOContext, conf
 
 	configDataMap, err := cpi.CreateVsphereConfig(config, *vsphereCloudConfigs, cpiSecretKey)
 	if err != nil {
-		config.Status.CPIStatus.Phase = vdov1alpha1.Failed
-		config.Status.CPIStatus.StatusMsg = fmt.Sprintf("could not create vsphere configmap %s", CONFIGMAP_NAME)
-		ctx.Logger.Error(err, "Error occurred when creating configDataMap for CPI")
+		r.updateCPIStatusForError(ctx, err, config, fmt.Sprintf("could not create vsphere configDataMap %s", CONFIGMAP_NAME))
 		return config, err
 	}
 
@@ -806,25 +795,22 @@ func (r *VDOConfigReconciler) reconcileConfigMap(ctx vdocontext.VDOContext, conf
 
 			vsphereConfigMap, err = cpi.CreateConfigMap(configDataMap, configMapKey)
 			if err != nil {
-				config.Status.CPIStatus.Phase = vdov1alpha1.Failed
-				config.Status.CPIStatus.StatusMsg = fmt.Sprintf("could not create vsphere configmap %s", CONFIGMAP_NAME)
-				ctx.Logger.Error(err, "Error occurred when creating configmap for CPI")
+				r.updateCPIStatusForError(ctx, err, config, fmt.Sprintf("could not create vsphere configmap %s", CONFIGMAP_NAME))
 				return config, err
 			}
 
 			err := r.Create(ctx, &vsphereConfigMap)
 			if err != nil && !apierrors.IsAlreadyExists(err) {
-				config.Status.CPIStatus.Phase = vdov1alpha1.Failed
-				config.Status.CPIStatus.StatusMsg = fmt.Sprintf("could not create vsphere configmap %s", CONFIGMAP_NAME)
-				return config, errors.Wrap(err, "error creating vsphere ConfigMap")
+				r.updateCPIStatusForError(ctx, err, config, fmt.Sprintf("could not create vsphere configmap %s", CONFIGMAP_NAME))
+
+				return config, err
 			}
 
 			err = r.updateCPIPhase(ctx, config, vdov1alpha1.Configuring, "")
 			return config, err
 		}
 
-		config.Status.CPIStatus.Phase = vdov1alpha1.Failed
-		config.Status.CPIStatus.StatusMsg = fmt.Sprintf("could not fetch configmap %s", CONFIGMAP_NAME)
+		r.updateCPIStatusForError(ctx, err, config, fmt.Sprintf("could not fetch configmap %s", CONFIGMAP_NAME))
 		return config, err
 	}
 
@@ -862,7 +848,7 @@ func (r *VDOConfigReconciler) reconcileCSISecret(ctx vdocontext.VDOContext, conf
 	ctx.Logger.V(4).Info("creating CSI secret config")
 	configData, err := csi.CreateCSISecretConfig(config, vsphereCloudConfig, vcUser, vcUserPwd, CSI_SECRET_CONFIG_FILE)
 	if err != nil {
-		ctx.Logger.Error(err, "unable to create csi config")
+		r.updateCSIStatusForError(ctx, err, config, "unable to create csi config")
 		return config, err
 	}
 
@@ -941,4 +927,39 @@ func (r *VDOConfigReconciler) fetchCpiDeploymentYamls(matrix CompatMatrix) (depl
 	cpiDeploymentYamls = matrix.CPISpecList[latestCpiVersion].DeploymentPaths
 
 	return cpiDeploymentYamls
+}
+
+func (r *VDOConfigReconciler) checkNodeExistence(ctx vdocontext.VDOContext, config *vdov1alpha1.VDOConfig, vsphereCloudConfigs *[]vdov1alpha1.VsphereCloudConfig, node v1.Node) (bool, error) {
+	for _, cloudConfig := range *vsphereCloudConfigs {
+		ctx.Logger.V(4).Info("fetching vc credentials for CPI secret", "vsphereCloudConfig", cloudConfig)
+		vcUser, vcUserPwd, err := r.fetchVcCredentials(ctx, cloudConfig)
+		if err != nil {
+			r.updateCPIStatusForError(ctx, err, config, "Error in fetching vc credentials for CPI configuration")
+			return false, err
+		}
+
+		vcIp := cloudConfig.Spec.VcIP
+		sess, err := session.GetOrCreate(ctx, vcIp, cloudConfig.Spec.DataCenters, vcUser, vcUserPwd, cloudConfig.Spec.Thumbprint)
+		if err != nil {
+			return false, errors.Wrapf(err, "Error establishing session with vcenter %s for user %s", vcIp, vcUser)
+		}
+
+		var nodeIP string
+		for _, address := range node.Status.Addresses {
+			if address.Type == v1.NodeInternalIP {
+				nodeIP = address.Address
+			}
+		}
+
+		vm, err := sess.GetVMByIP(ctx, nodeIP)
+		if err != nil {
+			return false, err
+		}
+
+		if vm != nil {
+			return true, nil
+		}
+
+	}
+	return false, nil
 }

--- a/controllers/vspherecloudconfig_controller.go
+++ b/controllers/vspherecloudconfig_controller.go
@@ -83,7 +83,7 @@ func (r *VsphereCloudConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 }
 
 func (r *VsphereCloudConfigReconciler) reconcileVCCredentials(ctx context.Context, config *vdov1alpha1.VsphereCloudConfig) (*vdov1alpha1.VsphereCloudConfig, error) {
-	var vcUser, vcUserPwd, datacenter string
+	var vcUser, vcUserPwd string
 
 	if len(config.Spec.Credentials) > 0 {
 		vcCredsSecret := &v1.Secret{}
@@ -103,12 +103,8 @@ func (r *VsphereCloudConfigReconciler) reconcileVCCredentials(ctx context.Contex
 		vcUserPwd = string(vcCredsSecret.Data["password"])
 	}
 
-	if len(config.Spec.DataCenters) > 0 {
-		datacenter = config.Spec.DataCenters[0]
-	}
-
 	vcIp := config.Spec.VcIP
-	sess, err := session.GetOrCreate(ctx, vcIp, datacenter, vcUser, vcUserPwd, config.Spec.Thumbprint)
+	sess, err := session.GetOrCreate(ctx, vcIp, config.Spec.DataCenters, vcUser, vcUserPwd, config.Spec.Thumbprint)
 	if err != nil {
 		config.Status.Config = vdov1alpha1.VsphereConfigFailed
 		config.Status.Message = fmt.Sprintf("Error establishing session with vcenter %s for user %s", vcIp, vcUser)

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/api/v1alpha1"
 	"net/url"
+	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -38,24 +40,35 @@ var sessionMU sync.Mutex
 // Session is a vSphere session with a configured Finder.
 type Session struct {
 	*govmomi.Client
-	Finder     *find.Finder
-	datacenter *object.Datacenter
+	datacenters []*object.Datacenter
+}
+
+type VirtualMachine struct {
+	*object.VirtualMachine
+	Datacenter *object.Datacenter
 }
 
 // GetOrCreate gets a cached session or creates a new one if one does not
 // already exist.
 func GetOrCreate(
 	ctx context.Context,
-	server, datacenter, username, password string, thumbprint string) (*Session, error) {
+	server string, datacenters []string, username, password, thumbprint string) (*Session, error) {
 	logger := log.FromContext(ctx).WithValues("session", "vcsession")
 	sessionMU.Lock()
 	defer sessionMU.Unlock()
 
-	sessionKey := server + username + datacenter
+	sessionKey := server + username
 	if cachedSession, ok := sessionCache[sessionKey]; ok {
 		if ok, _ := cachedSession.SessionManager.SessionIsActive(ctx); ok {
-			logger.V(2).Info("found active cached vSphere client session", "server", server, "datacenter", datacenter)
-			return &cachedSession, nil
+			logger.V(2).Info("found active cached vSphere client session", "server", server)
+
+			var DCListCachedSession []string
+			for _, dc := range cachedSession.datacenters {
+				DCListCachedSession = append(DCListCachedSession, dc.Name())
+			}
+			if reflect.DeepEqual(datacenters, DCListCachedSession) {
+				return &cachedSession, nil
+			}
 		}
 	}
 
@@ -76,20 +89,24 @@ func GetOrCreate(
 	session := Session{Client: client}
 	session.UserAgent = v1alpha1.GroupVersion.String()
 	// Assign the finder to the session.
-	session.Finder = find.NewFinder(session.Client.Client, false)
+	finder := find.NewFinder(session.Client.Client, false)
 
-	// Assign the datacenter if one was specified.
-	dc, err := session.Finder.DatacenterOrDefault(ctx, datacenter)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to find datacenter %q", datacenter)
+	if len(datacenters) > 0 {
+		for _, datacenter := range datacenters {
+
+			// Assign the datacenter if one was specified.
+			dc, err := finder.Datacenter(ctx, datacenter)
+			if err != nil {
+				return nil, errors.Wrapf(err, "unable to find datacenter %q", datacenter)
+			}
+			if dc != nil {
+				session.datacenters = append(session.datacenters, dc)
+			}
+			logger.V(2).Info("cached vSphere client session", "server", server, "datacenter", datacenter)
+		}
+
 	}
-	session.datacenter = dc
-	session.Finder.SetDatacenter(dc)
-
-	// Cache the session.
 	sessionCache[sessionKey] = session
-
-	logger.V(2).Info("cached vSphere client session", "server", server, "datacenter", datacenter)
 
 	return &session, nil
 }
@@ -120,28 +137,22 @@ func newClient(ctx context.Context, url *url.URL, thumbprint string) (*govmomi.C
 	return c, nil
 }
 
-// FindByBIOSUUID finds an object by its BIOS UUID.
-//
-// To avoid comments about this function's name, please see the Golang
-// WIKI https://github.com/golang/go/wiki/CodeReviewComments#initialisms.
-// This function is named in accordance with the example "XMLHTTP".
-func (s *Session) FindByBIOSUUID(ctx context.Context, uuid string) (object.Reference, error) {
-	return s.findByUUID(ctx, uuid, false)
-}
-
-// FindByInstanceUUID finds an object by its instance UUID.
-func (s *Session) FindByInstanceUUID(ctx context.Context, uuid string) (object.Reference, error) {
-	return s.findByUUID(ctx, uuid, true)
-}
-
-func (s *Session) findByUUID(ctx context.Context, uuid string, findByInstanceUUID bool) (object.Reference, error) {
-	if s.Client == nil {
-		return nil, errors.New("vSphere client is not initialized")
+func (s *Session) GetVMByIP(ctx context.Context, ipAddy string) (*VirtualMachine, error) {
+	if len(s.datacenters) > 0 {
+	dcloop:
+		for _, datacenter := range s.datacenters {
+			i := object.NewSearchIndex(datacenter.Client())
+			ipAddy = strings.ToLower(strings.TrimSpace(ipAddy))
+			svm, err := i.FindByIp(ctx, datacenter, ipAddy, true)
+			if err != nil {
+				return nil, err
+			}
+			if svm == nil {
+				continue dcloop
+			}
+			virtualMachine := VirtualMachine{svm.(*object.VirtualMachine), datacenter}
+			return &virtualMachine, nil
+		}
 	}
-	si := object.NewSearchIndex(s.Client.Client)
-	ref, err := si.FindByUuid(ctx, s.datacenter, uuid, true, &findByInstanceUUID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error finding object by uuid %q", uuid)
-	}
-	return ref, nil
+	return nil, nil
 }

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -43,7 +43,7 @@ func TestSession(t *testing.T) {
 
 	authSession, err := GetOrCreate(
 		context.Background(),
-		s.Server.URL, "",
+		s.Server.URL, []string{},
 		s.URL.User.Username(), pass, "")
 	Expect(err).To(BeNil())
 	Expect(authSession).NotTo(BeNil())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
Earlier, VDO would have tried to configure all the nodes for Cloud Provider irrespective of presence of taints (in case of missing taints, taints would have been added by VDO) 
Also, there was no explicit check for nodes availability in the vspherecloudconfig resource. 

Going ahead, based on the presence of taints and availability of node in the vsphereCloudConfig resource, VDO would configure CPI for the same. 

This PR brings in the following changes:
1. supports multi-datacenter configurations 
2.  Node availability and taints check based CPI configuraion:
     - fetch nodes for Cloud Provider based on Node-uninitialized  taint 
     - checking the availability of nodes in all vsphereCloudConfig resources configurations for Cloud Provider 
     - remove taint reconciler function for adding taints on untainted nodes

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #

**Test Report Added?**:
/kind TESTED


**Test Report**:
<!--
*Please provide the test report link (public accessible, screen shot or copy paste the test report, 
or add the testing details.
-->
Testing in progress for multiple cases. 



**Special notes for your reviewer**: