### PR TITLE
add implementation for getting CPI nodes and support for multi Datacenters

### DIFF
--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -18,4 +18,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: vmware.com/vdo
-  newTag: 16bf15d
+  newTag: 196775e

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -18,4 +18,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: vmware.com/vdo
-  newTag: 802d142
+  newTag: 41c68e2

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -18,4 +18,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: vmware.com/vdo
-  newTag: 41c68e2
+  newTag: 16bf15d

--- a/controllers/vdoconfig_controller.go
+++ b/controllers/vdoconfig_controller.go
@@ -54,7 +54,6 @@ import (
 
 const (
 	CLOUD_PROVIDER_INIT_TAINT_KEY = "node.cloudprovider.kubernetes.io/uninitialized"
-	TAINT_NOSCHEDULE_KEY          = "NoSchedule"
 	VDO_NODE_LABEL_KEY            = "vdo.vmware.com/vdoconfig"
 	VDO_NAMESPACE                 = "vmware-system-vdo"
 	CPI_DEPLOYMENT_NAME           = "vsphere-cloud-controller-manager"
@@ -78,6 +77,8 @@ type VDOConfigReconciler struct {
 	CsiDeploymentYamls []string
 	CpiDeploymentYamls []string
 }
+
+var NodeAvailabilityMap = make(map[string]bool)
 
 // +kubebuilder:rbac:groups=vdo.vmware.com,resources=vdoconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=vdo.vmware.com,resources=vdoconfigs/status,verbs=get;update;patch
@@ -233,7 +234,7 @@ func (r *VDOConfigReconciler) fetchVsphereVersions(vdoctx vdocontext.VDOContext,
 }
 
 func (r *VDOConfigReconciler) getVcSession(vdoctx vdocontext.VDOContext, config *vdov1alpha1.VsphereCloudConfig) (*session.Session, error) {
-	var vcUser, vcUserPwd, datacenter string
+	var vcUser, vcUserPwd string
 
 	vcUser, vcUserPwd, err := r.fetchVcCredentials(vdoctx, *config)
 
@@ -241,12 +242,9 @@ func (r *VDOConfigReconciler) getVcSession(vdoctx vdocontext.VDOContext, config 
 		return nil, errors.Wrapf(err, "Error fetching vcenter credentials ")
 	}
 
-	if len(config.Spec.DataCenters) > 0 {
-		datacenter = config.Spec.DataCenters[0]
-	}
 
 	vcIp := config.Spec.VcIP
-	sess, err := session.GetOrCreate(vdoctx, vcIp, datacenter, vcUser, vcUserPwd, config.Spec.Thumbprint)
+	sess, err := session.GetOrCreate(vdoctx, vcIp, config.Spec.DataCenters, vcUser, vcUserPwd, config.Spec.Thumbprint)
 	if err != nil {
 		config.Status.Config = vdov1alpha1.VsphereConfigFailed
 		config.Status.Message = fmt.Sprintf("Error establishing session with vcenter %s for user %s", vcIp, vcUser)
@@ -295,20 +293,6 @@ func (r *VDOConfigReconciler) reconcileCPIConfiguration(vdoctx vdocontext.VDOCon
 		return ctrl.Result{}, err
 	}
 
-	vdoctx.Logger.V(4).Info("reconciling node taint for CPI")
-	err = r.reconcileNodeTaint(vdoctx, clientset)
-	if err != nil {
-		r.updateCPIStatusForError(vdoctx, err, vdoConfig, "Error in reconcile of node taint for CPI configuration")
-		return ctrl.Result{}, err
-	}
-
-	vdoctx.Logger.V(4).Info("reconciling node label for CPI")
-	err = r.reconcileNodeLabel(vdoctx, req, clientset)
-	if err != nil {
-		r.updateCPIStatusForError(vdoctx, err, vdoConfig, "Error in reconcile of node label for CPI configuration")
-		return ctrl.Result{}, err
-	}
-
 	vdoctx.Logger.V(4).Info("reconciling deployment for CPI")
 	updateStatus, err := r.reconcileCPIDeployment(vdoctx)
 	if err != nil {
@@ -339,9 +323,16 @@ func (r *VDOConfigReconciler) reconcileCPIConfiguration(vdoctx vdocontext.VDOCon
 	}
 
 	vdoctx.Logger.Info("reconciling node providerID")
-	config, err := r.reconcileNodeProviderID(vdoctx, vdoConfig, clientset)
+	config, err, nodeList := r.reconcileNodeProviderID(vdoctx, vdoConfig, clientset, &vsphereCloudConfigItems)
 	if err != nil {
-		r.updateCPIStatusForError(vdoctx, err, vdoConfig, "Error in reconcile of Provider ID for CPI")
+		r.updateCPIStatusForError(vdoctx, err, vdoConfig, err.Error())
+		return ctrl.Result{}, err
+	}
+
+	vdoctx.Logger.V(4).Info("reconciling node label for CPI")
+	err = r.reconcileNodeLabel(vdoctx, req, clientset, nodeList)
+	if err != nil {
+		r.updateCPIStatusForError(vdoctx, err, vdoConfig, err.Error())
 		return ctrl.Result{}, err
 	}
 
@@ -668,51 +659,13 @@ func (r *VDOConfigReconciler) updateVdoConfigWithNodeStatus(ctx context.Context,
 	return nil
 }
 
-func (r *VDOConfigReconciler) reconcileNodeTaint(ctx context.Context, clientset *kubernetes.Clientset) error {
-	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return errors.Wrapf(err, "Unable to fetch list of nodes")
-	}
+func (r *VDOConfigReconciler) reconcileNodeLabel(ctx vdocontext.VDOContext, req ctrl.Request, clientset *kubernetes.Clientset, nodeList []v1.Node) error {
 
-nodeLoop:
-	for _, node := range nodes.Items {
-		for _, taint := range node.Spec.Taints {
-			if taint.Key == CLOUD_PROVIDER_INIT_TAINT_KEY {
-				continue nodeLoop
-			}
-		}
-
-		r.Logger.Info("adding taint", "name", CLOUD_PROVIDER_INIT_TAINT_KEY)
-
-		taint := v1.Taint{
-			Key:       CLOUD_PROVIDER_INIT_TAINT_KEY,
-			Value:     "true",
-			Effect:    TAINT_NOSCHEDULE_KEY,
-			TimeAdded: nil,
-		}
-
-		node.Spec.Taints = append(node.Spec.Taints, taint)
-
-		_, err := clientset.CoreV1().Nodes().Update(ctx, &node, metav1.UpdateOptions{})
-		if err != nil {
-			return errors.Wrapf(err, "Error when updating taint %s on node %s", CLOUD_PROVIDER_INIT_TAINT_KEY, node.Name)
-		}
-	}
-
-	return nil
-}
-
-func (r *VDOConfigReconciler) reconcileNodeLabel(ctx vdocontext.VDOContext, req ctrl.Request, clientset *kubernetes.Clientset) error {
-	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
-	if err != nil {
-		return errors.Wrapf(err, "Unable to fetch list of nodes")
-	}
-
-	for _, node := range nodes.Items {
+	for _, node := range nodeList {
 		if _, ok := node.Labels[VDO_NODE_LABEL_KEY]; !ok {
 			r.Logger.Info("adding node label", "name", VDO_NODE_LABEL_KEY)
 			node.Labels[VDO_NODE_LABEL_KEY] = req.Name
-			_, err = clientset.CoreV1().Nodes().Update(ctx, &node, metav1.UpdateOptions{})
+			_, err := clientset.CoreV1().Nodes().Update(ctx, &node, metav1.UpdateOptions{})
 			if err != nil {
 				return errors.Wrapf(err, "Unable to update label on node")
 			}
@@ -722,32 +675,70 @@ func (r *VDOConfigReconciler) reconcileNodeLabel(ctx vdocontext.VDOContext, req 
 	return nil
 }
 
-func (r *VDOConfigReconciler) reconcileNodeProviderID(ctx vdocontext.VDOContext, config *vdov1alpha1.VDOConfig, clientset *kubernetes.Clientset) (*vdov1alpha1.VDOConfig, error) {
+func (r *VDOConfigReconciler) reconcileNodeProviderID(ctx vdocontext.VDOContext, config *vdov1alpha1.VDOConfig, clientset *kubernetes.Clientset, vsphereCloudConfigs *[]vdov1alpha1.VsphereCloudConfig) (*vdov1alpha1.VDOConfig, error, []v1.Node) {
 	nodeStatus := make(map[string]vdov1alpha1.NodeStatus)
-	cpiStatus := vdov1alpha1.Configured
+	var NodeList []v1.Node
 
+	cpiStatus := vdov1alpha1.Configured
 	nodes, err := clientset.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
 	if err != nil {
-		return config, errors.Wrapf(err, "Unable to fetch list of nodes")
+		return config, errors.Wrapf(err, "Error reconciling the providerID for CPI, unable to fetch list of nodes"), NodeList
 	}
 
+nodeLoop:
 	for _, node := range nodes.Items {
 		if len(node.Spec.ProviderID) > 0 {
 			nodeStatus[node.Name] = vdov1alpha1.NodeStatusReady
-		} else {
-			nodeStatus[node.Name] = vdov1alpha1.NodeStatusPending
-			cpiStatus = vdov1alpha1.Configuring
+			NodeList = append(NodeList, node)
+			r.Logger.Info(fmt.Sprintf("Added %s node to NodeList", node.Name))
+			continue nodeLoop
 		}
+
+		for _, taint := range node.Spec.Taints {
+			if taint.Key == CLOUD_PROVIDER_INIT_TAINT_KEY {
+
+				if val, ok := NodeAvailabilityMap[node.Name]; ok {
+					if val {
+						nodeStatus[node.Name] = vdov1alpha1.NodeStatusPending
+						cpiStatus = vdov1alpha1.Configuring
+						NodeList = append(NodeList, node)
+						r.Logger.Info(fmt.Sprintf("Added %s node to NodeList", node.Name))
+						continue nodeLoop
+					}
+				}
+
+				NodeAvailabilityMap[node.Name], err = r.checkNodeExistence(ctx, config, vsphereCloudConfigs, node)
+				if err != nil {
+					return config, errors.Wrapf(err, "Error reconciling the providerID for CPI"), NodeList
+				}
+
+				if val, ok := NodeAvailabilityMap[node.Name]; ok {
+					if val {
+						nodeStatus[node.Name] = vdov1alpha1.NodeStatusPending
+						cpiStatus = vdov1alpha1.Configuring
+						NodeList = append(NodeList, node)
+						r.Logger.Info(fmt.Sprintf("Added %s node to NodeList", node.Name))
+						continue nodeLoop
+					}
+				}
+
+				errorMsg := fmt.Sprintf(" Cloud Provider is not configured to manage the node %s. Please check your cloud Provider settings. ", node.Name)
+				r.updateCPIStatusForError(ctx, errors.New(errorMsg), config, errorMsg)
+				return config, errors.New(errorMsg), NodeList
+			}
+
+		}
+
 	}
 
 	if config.Status.CPIStatus.Phase != cpiStatus ||
 		!reflect.DeepEqual(config.Status.CPIStatus.NodeStatus, nodeStatus) {
 		config.Status.CPIStatus.NodeStatus = nodeStatus
 		config.Status.CPIStatus.Phase = cpiStatus
-		return config, nil
+		return config, nil, NodeList
 	}
 
-	return nil, nil
+	return nil, nil, NodeList
 }
 
 // SetupWithManager sets up the controller with the Manager.
@@ -807,8 +798,7 @@ func (r *VDOConfigReconciler) reconcileCPISecret(ctx vdocontext.VDOContext, conf
 
 			err = r.Create(ctx, &cpiSecret)
 			if err != nil {
-				config.Status.CPIStatus.Phase = vdov1alpha1.Failed
-				config.Status.CPIStatus.StatusMsg = fmt.Sprintf("could not create cpi secret %s", cpiSecret.Name)
+				r.updateCPIStatusForError(ctx, err, config, fmt.Sprintf("could not create cpi secret %s", cpiSecret.Name))
 				return config, errors.Wrap(err, "error creating cpi secret")
 			}
 
@@ -816,9 +806,7 @@ func (r *VDOConfigReconciler) reconcileCPISecret(ctx vdocontext.VDOContext, conf
 			err = r.updateCPIPhase(ctx, config, vdov1alpha1.Configuring, "")
 			return config, err
 		}
-
-		config.Status.CPIStatus.StatusMsg = fmt.Sprintf("unable to fetch secret %s", cpiSecret.Name)
-		config.Status.CPIStatus.Phase = vdov1alpha1.Failed
+		r.updateCPIStatusForError(ctx, err, config, fmt.Sprintf("unable to fetch secret %s", cpiSecret.Name))
 		return config, err
 	}
 
@@ -830,8 +818,7 @@ func (r *VDOConfigReconciler) reconcileCPISecret(ctx vdocontext.VDOContext, conf
 		err = r.Update(ctx, &cpiSecret)
 		if err != nil {
 			ctx.Logger.Error(err, "error occurred when updating cpiSecret")
-			config.Status.CPIStatus.Phase = vdov1alpha1.Failed
-			config.Status.CPIStatus.StatusMsg = fmt.Sprintf("could not update cpi secret %s", cpiSecret.Name)
+			r.updateCPIStatusForError(ctx, err, config, fmt.Sprintf("could not update cpi secret %s", cpiSecret.Name))
 			return config, err
 		}
 		err = r.updateCPIPhase(ctx, config, vdov1alpha1.Configuring, "")
@@ -850,9 +837,7 @@ func (r *VDOConfigReconciler) reconcileConfigMap(ctx vdocontext.VDOContext, conf
 
 	configDataMap, err := cpi.CreateVsphereConfig(config, *vsphereCloudConfigs, cpiSecretKey)
 	if err != nil {
-		config.Status.CPIStatus.Phase = vdov1alpha1.Failed
-		config.Status.CPIStatus.StatusMsg = fmt.Sprintf("could not create vsphere configmap %s", CONFIGMAP_NAME)
-		ctx.Logger.Error(err, "Error occurred when creating configDataMap for CPI")
+		r.updateCPIStatusForError(ctx, err, config, fmt.Sprintf("could not create vsphere configDataMap %s", CONFIGMAP_NAME))
 		return config, err
 	}
 
@@ -865,25 +850,22 @@ func (r *VDOConfigReconciler) reconcileConfigMap(ctx vdocontext.VDOContext, conf
 
 			vsphereConfigMap, err = cpi.CreateConfigMap(configDataMap, configMapKey)
 			if err != nil {
-				config.Status.CPIStatus.Phase = vdov1alpha1.Failed
-				config.Status.CPIStatus.StatusMsg = fmt.Sprintf("could not create vsphere configmap %s", CONFIGMAP_NAME)
-				ctx.Logger.Error(err, "Error occurred when creating configmap for CPI")
+				r.updateCPIStatusForError(ctx, err, config, fmt.Sprintf("could not create vsphere configmap %s", CONFIGMAP_NAME))
 				return config, err
 			}
 
 			err := r.Create(ctx, &vsphereConfigMap)
 			if err != nil && !apierrors.IsAlreadyExists(err) {
-				config.Status.CPIStatus.Phase = vdov1alpha1.Failed
-				config.Status.CPIStatus.StatusMsg = fmt.Sprintf("could not create vsphere configmap %s", CONFIGMAP_NAME)
-				return config, errors.Wrap(err, "error creating vsphere ConfigMap")
+				r.updateCPIStatusForError(ctx, err, config, fmt.Sprintf("could not create vsphere configmap %s", CONFIGMAP_NAME))
+
+				return config, err
 			}
 
 			err = r.updateCPIPhase(ctx, config, vdov1alpha1.Configuring, "")
 			return config, err
 		}
 
-		config.Status.CPIStatus.Phase = vdov1alpha1.Failed
-		config.Status.CPIStatus.StatusMsg = fmt.Sprintf("could not fetch configmap %s", CONFIGMAP_NAME)
+		r.updateCPIStatusForError(ctx, err, config, fmt.Sprintf("could not fetch configmap %s", CONFIGMAP_NAME))
 		return config, err
 	}
 
@@ -921,7 +903,7 @@ func (r *VDOConfigReconciler) reconcileCSISecret(ctx vdocontext.VDOContext, conf
 	ctx.Logger.V(4).Info("creating CSI secret config")
 	configData, err := csi.CreateCSISecretConfig(config, vsphereCloudConfig, vcUser, vcUserPwd, CSI_SECRET_CONFIG_FILE)
 	if err != nil {
-		ctx.Logger.Error(err, "unable to create csi config")
+		r.updateCSIStatusForError(ctx, err, config, "unable to create csi config")
 		return config, err
 	}
 
@@ -1128,4 +1110,39 @@ func (r *VDOConfigReconciler) CheckCompatAndRetrieveSpec(ctx vdocontext.VDOConte
 	}
 
 	return nil
+}
+
+func (r *VDOConfigReconciler) checkNodeExistence(ctx vdocontext.VDOContext, config *vdov1alpha1.VDOConfig, vsphereCloudConfigs *[]vdov1alpha1.VsphereCloudConfig, node v1.Node) (bool, error) {
+	for _, cloudConfig := range *vsphereCloudConfigs {
+		ctx.Logger.V(4).Info("fetching vc credentials for CPI secret", "vsphereCloudConfig", cloudConfig)
+		vcUser, vcUserPwd, err := r.fetchVcCredentials(ctx, cloudConfig)
+		if err != nil {
+			r.updateCPIStatusForError(ctx, err, config, "Error in fetching vc credentials for CPI configuration")
+			return false, err
+		}
+
+		vcIp := cloudConfig.Spec.VcIP
+		sess, err := session.GetOrCreate(ctx, vcIp, cloudConfig.Spec.DataCenters, vcUser, vcUserPwd, cloudConfig.Spec.Thumbprint)
+		if err != nil {
+			return false, errors.Wrapf(err, "Error establishing session with vcenter %s for user %s", vcIp, vcUser)
+		}
+
+		var nodeIP string
+		for _, address := range node.Status.Addresses {
+			if address.Type == v1.NodeInternalIP {
+				nodeIP = address.Address
+			}
+		}
+
+		vm, err := sess.GetVMByIP(ctx, nodeIP)
+		if err != nil {
+			return false, err
+		}
+
+		if vm != nil {
+			return true, nil
+		}
+
+	}
+	return false, nil
 }

--- a/controllers/vdoconfig_controller.go
+++ b/controllers/vdoconfig_controller.go
@@ -324,20 +324,20 @@ func (r *VDOConfigReconciler) reconcileCPIConfiguration(vdoctx vdocontext.VDOCon
 	}
 
 	vdoctx.Logger.Info("reconciling node providerID")
-	vdoConfig, err = r.reconcileNodeProviderID(vdoctx, vdoConfig, clientset, &vsphereCloudConfigItems)
+	config, err := r.reconcileNodeProviderID(vdoctx, vdoConfig, clientset, &vsphereCloudConfigItems)
 	if err != nil {
 		r.updateCPIStatusForError(vdoctx, err, vdoConfig, err.Error())
 		return ctrl.Result{}, err
 	}
 
 	vdoctx.Logger.V(4).Info("reconciling node label for CPI")
-	err = r.reconcileNodeLabel(vdoctx, req, clientset, vdoConfig)
+	err = r.reconcileNodeLabel(vdoctx, req, clientset, config)
 	if err != nil {
 		r.updateCPIStatusForError(vdoctx, err, vdoConfig, err.Error())
 		return ctrl.Result{}, err
 	}
 
-	if vdoConfig != nil {
+	if config != nil {
 		err = r.updateVdoConfigWithNodeStatus(vdoctx, vdoConfig, vdoConfig.Status.CPIStatus.Phase, vdoConfig.Status.CPIStatus.NodeStatus)
 		if err != nil {
 			return ctrl.Result{}, err
@@ -744,7 +744,7 @@ nodeLoop:
 		return config, nil
 	}
 
-	return config, nil
+	return nil, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.

--- a/controllers/vdoconfig_controller.go
+++ b/controllers/vdoconfig_controller.go
@@ -323,21 +323,21 @@ func (r *VDOConfigReconciler) reconcileCPIConfiguration(vdoctx vdocontext.VDOCon
 		}
 	}
 
-	vdoctx.Logger.Info("reconciling node providerID")
-	config, err := r.reconcileNodeProviderID(vdoctx, vdoConfig, clientset, &vsphereCloudConfigItems)
-	if err != nil {
-		r.updateCPIStatusForError(vdoctx, err, vdoConfig, err.Error())
-		return ctrl.Result{}, err
-	}
-
 	vdoctx.Logger.V(4).Info("reconciling node label for CPI")
-	err = r.reconcileNodeLabel(vdoctx, req, clientset, config)
+	err = r.reconcileNodeLabel(vdoctx, req, clientset, vdoConfig)
 	if err != nil {
 		r.updateCPIStatusForError(vdoctx, err, vdoConfig, err.Error())
 		return ctrl.Result{}, err
 	}
 
-	if config != nil {
+	vdoctx.Logger.Info("reconciling node providerID")
+	vdoConfig, err = r.reconcileNodeProviderID(vdoctx, vdoConfig, clientset, &vsphereCloudConfigItems)
+	if err != nil {
+		r.updateCPIStatusForError(vdoctx, err, vdoConfig, err.Error())
+		return ctrl.Result{}, err
+	}
+
+	if vdoConfig != nil {
 		err = r.updateVdoConfigWithNodeStatus(vdoctx, vdoConfig, vdoConfig.Status.CPIStatus.Phase, vdoConfig.Status.CPIStatus.NodeStatus)
 		if err != nil {
 			return ctrl.Result{}, err

--- a/controllers/vdoconfig_controller.go
+++ b/controllers/vdoconfig_controller.go
@@ -81,7 +81,7 @@ type VDOConfigReconciler struct {
 
 var (
 	NodeAvailabilityMap = make(map[string]bool)
-	SessionFunction = session.GetOrCreate
+	SessionFunction     = session.GetOrCreate
 )
 
 // +kubebuilder:rbac:groups=vdo.vmware.com,resources=vdoconfigs,verbs=get;list;watch;create;update;patch;delete
@@ -245,7 +245,6 @@ func (r *VDOConfigReconciler) getVcSession(vdoctx vdocontext.VDOContext, config 
 	if err != nil {
 		return nil, errors.Wrapf(err, "Error fetching vcenter credentials ")
 	}
-
 
 	vcIp := config.Spec.VcIP
 	sess, err := session.GetOrCreate(vdoctx, vcIp, config.Spec.DataCenters, vcUser, vcUserPwd, config.Spec.Thumbprint)
@@ -671,8 +670,8 @@ func (r *VDOConfigReconciler) reconcileNodeLabel(ctx vdocontext.VDOContext, req 
 	}
 nodeloop:
 	for _, node := range nodes.Items {
-		if val, ok := nodeAvailabilityMap[node.Name]; ok{
-			if val{
+		if val, ok := nodeAvailabilityMap[node.Name]; ok {
+			if val {
 				if node.Labels == nil {
 					node.Labels = make(map[string]string)
 				}
@@ -695,7 +694,7 @@ nodeloop:
 	return nil
 }
 
-func (r *VDOConfigReconciler) reconcileNodeProviderID(ctx vdocontext.VDOContext, config *vdov1alpha1.VDOConfig, clientset kubernetes.Interface, vsphereCloudConfigs *[]vdov1alpha1.VsphereCloudConfig) (*vdov1alpha1.VDOConfig,  map[string]bool, error) {
+func (r *VDOConfigReconciler) reconcileNodeProviderID(ctx vdocontext.VDOContext, config *vdov1alpha1.VDOConfig, clientset kubernetes.Interface, vsphereCloudConfigs *[]vdov1alpha1.VsphereCloudConfig) (*vdov1alpha1.VDOConfig, map[string]bool, error) {
 	nodeStatus := make(map[string]vdov1alpha1.NodeStatus)
 
 	cpiStatus := vdov1alpha1.Configured
@@ -709,7 +708,7 @@ nodeLoop:
 		if len(node.Spec.ProviderID) > 0 {
 			nodeStatus[node.Name] = vdov1alpha1.NodeStatusReady
 			NodeAvailabilityMap[node.Name] = true
-			r.Logger.Info("Adding to Available nodes","node",  node.Name)
+			r.Logger.Info("Adding to Available nodes", "node", node.Name)
 			continue nodeLoop
 		}
 
@@ -720,7 +719,7 @@ nodeLoop:
 					if val {
 						nodeStatus[node.Name] = vdov1alpha1.NodeStatusPending
 						cpiStatus = vdov1alpha1.Configuring
-						r.Logger.Info("Adding to Available nodes","node",  node.Name)
+						r.Logger.Info("Adding to Available nodes", "node", node.Name)
 						continue nodeLoop
 					}
 				}
@@ -734,7 +733,7 @@ nodeLoop:
 					if val {
 						nodeStatus[node.Name] = vdov1alpha1.NodeStatusPending
 						cpiStatus = vdov1alpha1.Configuring
-						r.Logger.Info("Adding to Available nodes","node",  node.Name)
+						r.Logger.Info("Adding to Available nodes", "node", node.Name)
 						continue nodeLoop
 					}
 				}

--- a/controllers/vdoconfig_controller.go
+++ b/controllers/vdoconfig_controller.go
@@ -82,7 +82,6 @@ type VDOConfigReconciler struct {
 var (
 	NodeAvailabilityMap = make(map[string]bool)
 	SessionFunction = session.GetOrCreate
-	//getVMFunction = GetVMByIP
 )
 
 // +kubebuilder:rbac:groups=vdo.vmware.com,resources=vdoconfigs,verbs=get;list;watch;create;update;patch;delete

--- a/controllers/vdoconfig_controller_test.go
+++ b/controllers/vdoconfig_controller_test.go
@@ -23,8 +23,8 @@ import (
 	. "github.com/onsi/gomega"
 	"github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/api/v1alpha1"
 	vdocontext "github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/context"
-	"github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/models"
 	"github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/drivers/cpi"
+	"github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/models"
 	v1 "k8s.io/api/apps/v1"
 	v12 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -387,7 +387,6 @@ var _ = Describe("TestReconcileNodeProviderID", func() {
 			Scheme: s,
 		}
 
-
 		vdoctx := vdocontext.VDOContext{
 			Context: ctx,
 			Logger:  r.Logger,
@@ -493,7 +492,8 @@ var _ = Describe("TestReconcileNodeLabel", func() {
 			err := r.reconcileNodeLabel(vdoctx, req, clientSet, testnodelist)
 			Expect(err).NotTo(HaveOccurred())
 
-			nodes, err := clientSet.CoreV1().Nodes().List(ctx,metav1.ListOptions{})
+			nodes, err := clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
 
 			for _, node := range nodes.Items {
 				Expect(node.Labels[VDO_NODE_LABEL_KEY]).Should(BeEquivalentTo(req.Name))

--- a/controllers/vdoconfig_controller_test.go
+++ b/controllers/vdoconfig_controller_test.go
@@ -32,9 +32,11 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
+	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fake2 "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
 var _ = Describe("TestReconcileCSIDeploymentStatus", func() {
@@ -282,60 +284,9 @@ var _ = Describe("TestReconcileConfigMap", func() {
 			Logger:  r.Logger,
 		}
 
-		cloudConfig1 := v1alpha1.VsphereCloudConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-resource",
-				Namespace: "default",
-			},
-			Spec: v1alpha1.VsphereCloudConfigSpec{
-				VcIP:        "1.1.1.1",
-				Insecure:    true,
-				Credentials: "secret-ref",
-				DataCenters: []string{"datacenter-1"},
-			},
-			Status: v1alpha1.VsphereCloudConfigStatus{},
-		}
-		cloudConfig2 := v1alpha1.VsphereCloudConfig{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "test-resource",
-				Namespace: "default",
-			},
-			Spec: v1alpha1.VsphereCloudConfigSpec{
-				VcIP:        "2.2.2.2",
-				Insecure:    true,
-				Credentials: "secret-ref",
-				DataCenters: []string{"datacenter-1"},
-			},
-			Status: v1alpha1.VsphereCloudConfigStatus{},
-		}
-		var cloudconfiglist []v1alpha1.VsphereCloudConfig
-		cloudconfiglist = append(cloudconfiglist, cloudConfig1, cloudConfig2)
+		cloudconfiglist := initializeVsphereConfigList()
 
-		vdoConfig := &v1alpha1.VDOConfig{
-			TypeMeta: metav1.TypeMeta{},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vdo-sample",
-				Namespace: "default",
-			},
-			Spec: v1alpha1.VDOConfigSpec{
-				CloudProvider: v1alpha1.CloudProviderConfig{
-					VsphereCloudConfigs: []string{"test-resource"},
-					Topology: v1alpha1.TopologyInfo{
-						Zone:   "k8s-zone-A",
-						Region: "k8s-region-A",
-					},
-				},
-				StorageProvider: v1alpha1.StorageProviderConfig{
-					VsphereCloudConfig:  "test-resource",
-					ClusterDistribution: "",
-					FileVolumes:         v1alpha1.FileVolume{},
-				},
-			},
-			Status: v1alpha1.VDOConfigStatus{
-				CPIStatus: v1alpha1.CPIStatus{},
-				CSIStatus: v1alpha1.CSIStatus{},
-			},
-		}
+		vdoConfig := initializeVDOConfig()
 
 		Expect(r.Create(ctx, vdoConfig)).Should(Succeed())
 
@@ -395,31 +346,7 @@ var _ = Describe("TestReconcileCSISecret", func() {
 			Status: v1alpha1.VsphereCloudConfigStatus{},
 		}
 
-		vdoConfig := &v1alpha1.VDOConfig{
-			TypeMeta: metav1.TypeMeta{},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      "vdo-sample",
-				Namespace: "default",
-			},
-			Spec: v1alpha1.VDOConfigSpec{
-				CloudProvider: v1alpha1.CloudProviderConfig{
-					VsphereCloudConfigs: []string{"test-resource"},
-					Topology: v1alpha1.TopologyInfo{
-						Zone:   "k8s-zone-A",
-						Region: "k8s-region-A",
-					},
-				},
-				StorageProvider: v1alpha1.StorageProviderConfig{
-					VsphereCloudConfig:  "test-resource",
-					ClusterDistribution: "",
-					FileVolumes:         v1alpha1.FileVolume{},
-				},
-			},
-			Status: v1alpha1.VDOConfigStatus{
-				CPIStatus: v1alpha1.CPIStatus{},
-				CSIStatus: v1alpha1.CSIStatus{},
-			},
-		}
+		vdoConfig := initializeVDOConfig()
 
 		BeforeEach(func() {
 			secret := &v12.Secret{
@@ -438,12 +365,204 @@ var _ = Describe("TestReconcileCSISecret", func() {
 			Expect(r.Create(ctx, vdoConfig)).Should(Succeed())
 		})
 
-		It("should reconcile configmap without error", func() {
+		It("should reconcile CSI secret without error", func() {
 			_, err := r.reconcileCSISecret(vdoctx, vdoConfig, &cloudConfig)
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
 })
+
+var _ = Describe("TestReconcileNodeProviderID", func() {
+
+	Context("When reconciling Node ProviderID succeeds", func() {
+		RegisterFailHandler(Fail)
+		ctx := context.Background()
+
+		s := scheme.Scheme
+		s.AddKnownTypes(v1alpha1.GroupVersion, &v1alpha1.VDOConfig{})
+
+		r := VDOConfigReconciler{
+			Client: fake2.NewClientBuilder().WithRuntimeObjects().Build(),
+			Logger: ctrllog.Log.WithName("VDOConfigControllerTest"),
+			Scheme: s,
+		}
+
+
+		vdoctx := vdocontext.VDOContext{
+			Context: ctx,
+			Logger:  r.Logger,
+		}
+
+		clientSet := fake.NewSimpleClientset()
+		Expect(clientSet).NotTo(BeNil())
+
+		cloudconfiglist := initializeVsphereConfigList()
+
+		vdoConfig := initializeVDOConfig()
+		Expect(r.Create(vdoctx, vdoConfig)).Should(Succeed())
+
+		node1 := v12.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-node1"},
+			Spec:       v12.NodeSpec{ProviderID: "vsphere://testid1"},
+		}
+
+		node2 := v12.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-node2"},
+			Spec:       v12.NodeSpec{ProviderID: "vsphere://testid2"},
+		}
+
+		testnodelist := map[string]bool{
+			node1.Name: true,
+			node2.Name: true,
+		}
+
+		It("should create the nodes without error", func() {
+			_, err := clientSet.CoreV1().Nodes().Create(vdoctx, &node1, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = clientSet.CoreV1().Nodes().Create(vdoctx, &node2, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should reconcile providerID without error", func() {
+			_, nodelist, err := r.reconcileNodeProviderID(vdoctx, vdoConfig, clientSet, &cloudconfiglist)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(reflect.DeepEqual(testnodelist, nodelist)).To(BeTrue())
+		})
+
+	})
+})
+
+var _ = Describe("TestReconcileNodeLabel", func() {
+	node1 := v12.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node1"},
+		Spec:       v12.NodeSpec{ProviderID: "vsphere://testid1"},
+	}
+
+	node2 := v12.Node{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-node2"},
+		Spec:       v12.NodeSpec{ProviderID: "vsphere://testid2"},
+	}
+
+	testnodelist := map[string]bool{
+		node1.Name: true,
+		node2.Name: true,
+	}
+
+	Context("When adding node label succeeds", func() {
+		RegisterFailHandler(Fail)
+		ctx := context.Background()
+
+		s := scheme.Scheme
+		s.AddKnownTypes(v1alpha1.GroupVersion, &v1alpha1.VDOConfig{})
+
+		r := VDOConfigReconciler{
+			Client: fake2.NewClientBuilder().WithRuntimeObjects().Build(),
+			Logger: ctrllog.Log.WithName("VDOConfigControllerTest"),
+			Scheme: s,
+		}
+
+		vdoctx := vdocontext.VDOContext{
+			Context: ctx,
+			Logger:  r.Logger,
+		}
+
+		clientSet := fake.NewSimpleClientset()
+		Expect(clientSet).NotTo(BeNil())
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "test-resource",
+				Namespace: "default",
+			},
+		}
+
+		vdoConfig := initializeVDOConfig()
+		Expect(r.Create(vdoctx, vdoConfig)).Should(Succeed())
+
+		It("should create the nodes without error", func() {
+			_, err := clientSet.CoreV1().Nodes().Create(vdoctx, &node1, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = clientSet.CoreV1().Nodes().Create(vdoctx, &node2, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("should reconcile node label without error", func() {
+
+			err := r.reconcileNodeLabel(vdoctx, req, clientSet, testnodelist)
+			Expect(err).NotTo(HaveOccurred())
+
+			nodes, err := clientSet.CoreV1().Nodes().List(ctx,metav1.ListOptions{})
+
+			for _, node := range nodes.Items {
+				Expect(node.Labels[VDO_NODE_LABEL_KEY]).Should(BeEquivalentTo(req.Name))
+			}
+
+		})
+	})
+})
+
+func initializeVsphereConfigList() []v1alpha1.VsphereCloudConfig {
+	cloudConfig1 := v1alpha1.VsphereCloudConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-resource",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.VsphereCloudConfigSpec{
+			VcIP:        "1.1.1.1",
+			Insecure:    true,
+			Credentials: "secret-ref",
+			DataCenters: []string{"datacenter-1"},
+		},
+		Status: v1alpha1.VsphereCloudConfigStatus{},
+	}
+	cloudConfig2 := v1alpha1.VsphereCloudConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-resource",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.VsphereCloudConfigSpec{
+			VcIP:        "2.2.2.2",
+			Insecure:    true,
+			Credentials: "secret-ref",
+			DataCenters: []string{"datacenter-1"},
+		},
+		Status: v1alpha1.VsphereCloudConfigStatus{},
+	}
+	var cloudconfiglist []v1alpha1.VsphereCloudConfig
+	cloudconfiglist = append(cloudconfiglist, cloudConfig1, cloudConfig2)
+	return cloudconfiglist
+}
+
+func initializeVDOConfig() *v1alpha1.VDOConfig {
+	vdoConfig := &v1alpha1.VDOConfig{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vdo-sample",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.VDOConfigSpec{
+			CloudProvider: v1alpha1.CloudProviderConfig{
+				VsphereCloudConfigs: []string{"test-resource"},
+				Topology: v1alpha1.TopologyInfo{
+					Zone:   "k8s-zone-A",
+					Region: "k8s-region-A",
+				},
+			},
+			StorageProvider: v1alpha1.StorageProviderConfig{
+				VsphereCloudConfig:  "test-resource",
+				ClusterDistribution: "",
+				FileVolumes:         v1alpha1.FileVolume{},
+			},
+		},
+		Status: v1alpha1.VDOConfigStatus{
+			CPIStatus: v1alpha1.CPIStatus{},
+			CSIStatus: v1alpha1.CSIStatus{},
+		},
+	}
+	return vdoConfig
+}
 
 var _ = Describe("TestfetchDeploymentYamls", func() {
 

--- a/controllers/vdoconfig_controller_test.go
+++ b/controllers/vdoconfig_controller_test.go
@@ -484,11 +484,9 @@ var _ = Describe("TestReconcileNodeProviderID", func() {
 
 		Expect(r.Client.Create(vdoctx, &secret)).Should(Succeed())
 
-		It("should create the nodes without error", func() {
-			_, err := clientSet.CoreV1().Nodes().Create(vdoctx, &node4, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
+		_, err := clientSet.CoreV1().Nodes().Create(vdoctx, &node4, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
 
-		})
 
 		It("should reconcile providerID without error", func() {
 			_, nodelist, err := r.reconcileNodeProviderID(vdoctx, vdoConfig, clientSet, &cloudconfiglist)
@@ -568,11 +566,9 @@ var _ = Describe("TestReconcileNodeProviderID", func() {
 			return &session.Session{}, nil
 		}
 
-		It("should create the node without error", func() {
-			_, err := clientSet.CoreV1().Nodes().Create(vdoctx, &node5, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
+		_, err := clientSet.CoreV1().Nodes().Create(vdoctx, &node5, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
 
-		})
 		It("should reconcile providerID without error", func() {
 			GetVMFn = func(ctx context.Context, ipAddy string, datacenters []*object.Datacenter) (*session.VirtualMachine, error) {
 				return &session.VirtualMachine{}, nil
@@ -642,11 +638,8 @@ var _ = Describe("TestReconcileNodeProviderID", func() {
 			return &session.Session{}, nil
 		}
 
-		It("should create the nodes without error", func() {
-			_, err := clientSet.CoreV1().Nodes().Create(vdoctx, &node6, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-		})
+		_, err := clientSet.CoreV1().Nodes().Create(vdoctx, &node6, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
 
 		It("should reconcile providerID with error", func() {
 			GetVMFn = func(ctx context.Context, ipAddy string, datacenters []*object.Datacenter) (*session.VirtualMachine, error) {
@@ -707,13 +700,11 @@ var _ = Describe("TestReconcileNodeLabel", func() {
 		vdoConfig := initializeVDOConfig()
 		Expect(r.Create(vdoctx, vdoConfig)).Should(Succeed())
 
-		It("should create the nodes without error", func() {
-			_, err := clientSet.CoreV1().Nodes().Create(vdoctx, &node1, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
+		_, err := clientSet.CoreV1().Nodes().Create(vdoctx, &node1, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
 
-			_, err = clientSet.CoreV1().Nodes().Create(vdoctx, &node2, metav1.CreateOptions{})
-			Expect(err).NotTo(HaveOccurred())
-		})
+		_, err = clientSet.CoreV1().Nodes().Create(vdoctx, &node2, metav1.CreateOptions{})
+		Expect(err).NotTo(HaveOccurred())
 
 		It("should reconcile node label without error", func() {
 			err := r.reconcileNodeLabel(vdoctx, req, clientSet, testnodelist)

--- a/controllers/vdoconfig_controller_test.go
+++ b/controllers/vdoconfig_controller_test.go
@@ -19,12 +19,15 @@ package controllers
 import (
 	"context"
 	"encoding/json"
+
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 	"github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/api/v1alpha1"
 	vdocontext "github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/context"
 	"github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/drivers/cpi"
 	"github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/models"
+	"github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/session"
+	"github.com/vmware/govmomi/object"
 	v1 "k8s.io/api/apps/v1"
 	v12 "k8s.io/api/core/v1"
 	storagev1 "k8s.io/api/storage/v1"
@@ -32,7 +35,6 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/kubernetes/scheme"
-	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fake2 "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
@@ -374,8 +376,9 @@ var _ = Describe("TestReconcileCSISecret", func() {
 
 var _ = Describe("TestReconcileNodeProviderID", func() {
 
-	Context("When reconciling Node ProviderID succeeds", func() {
+	Context("When ProviderID is present on all the nodes", func() {
 		RegisterFailHandler(Fail)
+
 		ctx := context.Background()
 
 		s := scheme.Scheme
@@ -410,26 +413,252 @@ var _ = Describe("TestReconcileNodeProviderID", func() {
 			Spec:       v12.NodeSpec{ProviderID: "vsphere://testid2"},
 		}
 
-		testnodelist := map[string]bool{
-			node1.Name: true,
-			node2.Name: true,
-		}
-
 		It("should create the nodes without error", func() {
 			_, err := clientSet.CoreV1().Nodes().Create(vdoctx, &node1, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
 
 			_, err = clientSet.CoreV1().Nodes().Create(vdoctx, &node2, metav1.CreateOptions{})
 			Expect(err).NotTo(HaveOccurred())
+
 		})
 
 		It("should reconcile providerID without error", func() {
 			_, nodelist, err := r.reconcileNodeProviderID(vdoctx, vdoConfig, clientSet, &cloudconfiglist)
 			Expect(err).NotTo(HaveOccurred())
-			Expect(reflect.DeepEqual(testnodelist, nodelist)).To(BeTrue())
+			val, ok := nodelist[node1.Name]
+			Expect(ok).To(BeTrue())
+			Expect(val).To(BeTrue())
+
 		})
 
 	})
+
+	Context("When both ProviderID and taint are absent", func() {
+		RegisterFailHandler(Fail)
+
+		ctx := context.Background()
+
+		s := scheme.Scheme
+		s.AddKnownTypes(v1alpha1.GroupVersion, &v1alpha1.VDOConfig{})
+
+		r := VDOConfigReconciler{
+			Client: fake2.NewClientBuilder().WithRuntimeObjects().Build(),
+			Logger: ctrllog.Log.WithName("VDOConfigControllerTest"),
+			Scheme: s,
+		}
+
+		vdoctx := vdocontext.VDOContext{
+			Context: ctx,
+			Logger:  r.Logger,
+		}
+
+		secret := v12.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret-ref",
+				Namespace: "kube-system",
+			},
+			Data: map[string][]byte{
+				"username": []byte("vc_user"),
+				"password": []byte("vc_pwd"),
+			},
+		}
+
+		node4 := v12.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-node4"},
+		}
+
+		clientSet := fake.NewSimpleClientset()
+		Expect(clientSet).NotTo(BeNil())
+
+		cloudconfiglist := initializeVsphereConfigList()
+		vdoConfig := initializeVDOConfig()
+
+		SessionFn = func(ctx context.Context,
+			server string, datacenters []string, username, password, thumbprint string) (*session.Session, error) {
+			return &session.Session{}, nil
+		}
+
+		GetVMFn = func(ctx context.Context, ipAddy string, datacenters []*object.Datacenter) (*session.VirtualMachine, error) {
+			return &session.VirtualMachine{}, nil
+		}
+
+		Expect(r.Client.Create(vdoctx, &secret)).Should(Succeed())
+
+		It("should create the nodes without error", func() {
+			_, err := clientSet.CoreV1().Nodes().Create(vdoctx, &node4, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		It("should reconcile providerID without error", func() {
+			_, nodelist, err := r.reconcileNodeProviderID(vdoctx, vdoConfig, clientSet, &cloudconfiglist)
+			Expect(err).NotTo(HaveOccurred())
+			_, ok := nodelist[node4.Name]
+			Expect(ok).To(BeFalse())
+
+		})
+
+	})
+
+	Context("When ProviderID is absent while taint is present and the node's DC/VC is mentioned in the vsphereCloudConfig resource", func() {
+		RegisterFailHandler(Fail)
+
+		ctx := context.Background()
+
+		s := scheme.Scheme
+		s.AddKnownTypes(v1alpha1.GroupVersion, &v1alpha1.VDOConfig{})
+
+		r := VDOConfigReconciler{
+			Client: fake2.NewClientBuilder().WithRuntimeObjects().Build(),
+			Logger: ctrllog.Log.WithName("VDOConfigControllerTest"),
+			Scheme: s,
+		}
+
+		vdoctx := vdocontext.VDOContext{
+			Context: ctx,
+			Logger:  r.Logger,
+		}
+
+		taint := v12.Taint{
+			Key:       CLOUD_PROVIDER_INIT_TAINT_KEY,
+			Value:     "true",
+			Effect:    TAINT_NOSCHEDULE_KEY,
+			TimeAdded: nil,
+		}
+		node5 := v12.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-node5"},
+			Spec:       v12.NodeSpec{Taints: []v12.Taint{taint}},
+		}
+
+		secret := v12.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret-ref",
+				Namespace: "kube-system",
+			},
+			Data: map[string][]byte{
+				"username": []byte("vc_user"),
+				"password": []byte("vc_pwd"),
+			},
+		}
+
+		Expect(r.Client.Create(vdoctx, &secret)).Should(Succeed())
+
+		clientSet := fake.NewSimpleClientset()
+		Expect(clientSet).NotTo(BeNil())
+
+		cloudConfig := v1alpha1.VsphereCloudConfig{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-resource",
+				Namespace: "default",
+			},
+			Spec: v1alpha1.VsphereCloudConfigSpec{
+				VcIP:        "1.1.1.1",
+				Insecure:    true,
+				Credentials: "secret-ref",
+				DataCenters: []string{"datacenter-1"},
+			},
+			Status: v1alpha1.VsphereCloudConfigStatus{},
+		}
+		cloudconfiglist := []v1alpha1.VsphereCloudConfig{cloudConfig}
+
+		vdoConfig := initializeVDOConfig()
+
+		SessionFn = func(ctx context.Context,
+			server string, datacenters []string, username, password, thumbprint string) (*session.Session, error) {
+			return &session.Session{}, nil
+		}
+
+		It("should create the node without error", func() {
+			_, err := clientSet.CoreV1().Nodes().Create(vdoctx, &node5, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+		It("should reconcile providerID without error", func() {
+			GetVMFn = func(ctx context.Context, ipAddy string, datacenters []*object.Datacenter) (*session.VirtualMachine, error) {
+				return &session.VirtualMachine{}, nil
+			}
+			_, nodelist, err := r.reconcileNodeProviderID(vdoctx, vdoConfig, clientSet, &cloudconfiglist)
+			Expect(err).NotTo(HaveOccurred())
+			val, ok := nodelist[node5.Name]
+			Expect(ok).To(BeTrue())
+			Expect(val).To(BeTrue())
+
+		})
+
+	})
+
+	Context("When taint is present but the node is not mentioned in the vsphereCloudConfigResource", func() {
+		RegisterFailHandler(Fail)
+
+		ctx := context.Background()
+
+		s := scheme.Scheme
+		s.AddKnownTypes(v1alpha1.GroupVersion, &v1alpha1.VDOConfig{})
+
+		r := VDOConfigReconciler{
+			Client: fake2.NewClientBuilder().WithRuntimeObjects().Build(),
+			Logger: ctrllog.Log.WithName("VDOConfigControllerTest"),
+			Scheme: s,
+		}
+
+		vdoctx := vdocontext.VDOContext{
+			Context: ctx,
+			Logger:  r.Logger,
+		}
+
+		taint := v12.Taint{
+			Key:       CLOUD_PROVIDER_INIT_TAINT_KEY,
+			Value:     "true",
+			Effect:    TAINT_NOSCHEDULE_KEY,
+			TimeAdded: nil,
+		}
+
+		node6 := v12.Node{
+			ObjectMeta: metav1.ObjectMeta{Name: "test-node6"},
+			Spec:       v12.NodeSpec{Taints: []v12.Taint{taint}},
+		}
+
+		secret := v12.Secret{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "secret-ref",
+				Namespace: "kube-system",
+			},
+			Data: map[string][]byte{
+				"username": []byte("vc_user"),
+				"password": []byte("vc_pwd"),
+			},
+		}
+
+		Expect(r.Client.Create(vdoctx, &secret)).Should(Succeed())
+		clientSet := fake.NewSimpleClientset()
+		Expect(clientSet).NotTo(BeNil())
+
+		cloudconfiglist := initializeVsphereConfigList()
+
+		vdoConfig := initializeVDOConfig()
+
+		SessionFn = func(ctx context.Context,
+			server string, datacenters []string, username, password, thumbprint string) (*session.Session, error) {
+			return &session.Session{}, nil
+		}
+
+		It("should create the nodes without error", func() {
+			_, err := clientSet.CoreV1().Nodes().Create(vdoctx, &node6, metav1.CreateOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		It("should reconcile providerID with error", func() {
+			GetVMFn = func(ctx context.Context, ipAddy string, datacenters []*object.Datacenter) (*session.VirtualMachine, error) {
+				return nil, nil
+			}
+			_, _, err := r.reconcileNodeProviderID(vdoctx, vdoConfig, clientSet, &cloudconfiglist)
+			Expect(err).To(HaveOccurred())
+
+		})
+
+	})
+
 })
 
 var _ = Describe("TestReconcileNodeLabel", func() {
@@ -440,15 +669,14 @@ var _ = Describe("TestReconcileNodeLabel", func() {
 
 	node2 := v12.Node{
 		ObjectMeta: metav1.ObjectMeta{Name: "test-node2"},
-		Spec:       v12.NodeSpec{ProviderID: "vsphere://testid2"},
 	}
 
 	testnodelist := map[string]bool{
 		node1.Name: true,
-		node2.Name: true,
+		node2.Name: false,
 	}
 
-	Context("When adding node label succeeds", func() {
+	Context("When reconciling node label succeeds", func() {
 		RegisterFailHandler(Fail)
 		ctx := context.Background()
 
@@ -488,7 +716,6 @@ var _ = Describe("TestReconcileNodeLabel", func() {
 		})
 
 		It("should reconcile node label without error", func() {
-
 			err := r.reconcileNodeLabel(vdoctx, req, clientSet, testnodelist)
 			Expect(err).NotTo(HaveOccurred())
 
@@ -496,73 +723,28 @@ var _ = Describe("TestReconcileNodeLabel", func() {
 			Expect(err).NotTo(HaveOccurred())
 
 			for _, node := range nodes.Items {
-				Expect(node.Labels[VDO_NODE_LABEL_KEY]).Should(BeEquivalentTo(req.Name))
+				if node.Name == "test-node1" {
+					Expect(node.Labels[VDO_NODE_LABEL_KEY]).Should(BeEquivalentTo(req.Name))
+				}
+			}
+		})
+
+		It("should not add label to the node", func() {
+
+			nodes, err := clientSet.CoreV1().Nodes().List(ctx, metav1.ListOptions{})
+			Expect(err).NotTo(HaveOccurred())
+
+			for _, node := range nodes.Items {
+				if node.Name == "test-node2" {
+					_, ok := node.Labels[VDO_NODE_LABEL_KEY]
+					Expect(ok).To(BeFalse())
+				}
 			}
 
 		})
+
 	})
 })
-
-func initializeVsphereConfigList() []v1alpha1.VsphereCloudConfig {
-	cloudConfig1 := v1alpha1.VsphereCloudConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-resource",
-			Namespace: "default",
-		},
-		Spec: v1alpha1.VsphereCloudConfigSpec{
-			VcIP:        "1.1.1.1",
-			Insecure:    true,
-			Credentials: "secret-ref",
-			DataCenters: []string{"datacenter-1"},
-		},
-		Status: v1alpha1.VsphereCloudConfigStatus{},
-	}
-	cloudConfig2 := v1alpha1.VsphereCloudConfig{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "test-resource",
-			Namespace: "default",
-		},
-		Spec: v1alpha1.VsphereCloudConfigSpec{
-			VcIP:        "2.2.2.2",
-			Insecure:    true,
-			Credentials: "secret-ref",
-			DataCenters: []string{"datacenter-1"},
-		},
-		Status: v1alpha1.VsphereCloudConfigStatus{},
-	}
-	var cloudconfiglist []v1alpha1.VsphereCloudConfig
-	cloudconfiglist = append(cloudconfiglist, cloudConfig1, cloudConfig2)
-	return cloudconfiglist
-}
-
-func initializeVDOConfig() *v1alpha1.VDOConfig {
-	vdoConfig := &v1alpha1.VDOConfig{
-		TypeMeta: metav1.TypeMeta{},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "vdo-sample",
-			Namespace: "default",
-		},
-		Spec: v1alpha1.VDOConfigSpec{
-			CloudProvider: v1alpha1.CloudProviderConfig{
-				VsphereCloudConfigs: []string{"test-resource"},
-				Topology: v1alpha1.TopologyInfo{
-					Zone:   "k8s-zone-A",
-					Region: "k8s-region-A",
-				},
-			},
-			StorageProvider: v1alpha1.StorageProviderConfig{
-				VsphereCloudConfig:  "test-resource",
-				ClusterDistribution: "",
-				FileVolumes:         v1alpha1.FileVolume{},
-			},
-		},
-		Status: v1alpha1.VDOConfigStatus{
-			CPIStatus: v1alpha1.CPIStatus{},
-			CSIStatus: v1alpha1.CSIStatus{},
-		},
-	}
-	return vdoConfig
-}
 
 var _ = Describe("TestfetchDeploymentYamls", func() {
 
@@ -708,3 +890,64 @@ var _ = Describe("TestfetchDeploymentYamls", func() {
 	})
 
 })
+
+func initializeVsphereConfigList() []v1alpha1.VsphereCloudConfig {
+	cloudConfig1 := v1alpha1.VsphereCloudConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-resource",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.VsphereCloudConfigSpec{
+			VcIP:        "1.1.1.1",
+			Insecure:    true,
+			Credentials: "secret-ref",
+			DataCenters: []string{"datacenter-1"},
+		},
+		Status: v1alpha1.VsphereCloudConfigStatus{},
+	}
+	cloudConfig2 := v1alpha1.VsphereCloudConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-resource",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.VsphereCloudConfigSpec{
+			VcIP:        "2.2.2.2",
+			Insecure:    true,
+			Credentials: "secret-ref",
+			DataCenters: []string{"datacenter-1"},
+		},
+		Status: v1alpha1.VsphereCloudConfigStatus{},
+	}
+	var cloudconfiglist []v1alpha1.VsphereCloudConfig
+	cloudconfiglist = append(cloudconfiglist, cloudConfig1, cloudConfig2)
+	return cloudconfiglist
+}
+
+func initializeVDOConfig() *v1alpha1.VDOConfig {
+	vdoConfig := &v1alpha1.VDOConfig{
+		TypeMeta: metav1.TypeMeta{},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "vdo-sample",
+			Namespace: "default",
+		},
+		Spec: v1alpha1.VDOConfigSpec{
+			CloudProvider: v1alpha1.CloudProviderConfig{
+				VsphereCloudConfigs: []string{"test-resource"},
+				Topology: v1alpha1.TopologyInfo{
+					Zone:   "k8s-zone-A",
+					Region: "k8s-region-A",
+				},
+			},
+			StorageProvider: v1alpha1.StorageProviderConfig{
+				VsphereCloudConfig:  "test-resource",
+				ClusterDistribution: "",
+				FileVolumes:         v1alpha1.FileVolume{},
+			},
+		},
+		Status: v1alpha1.VDOConfigStatus{
+			CPIStatus: v1alpha1.CPIStatus{},
+			CSIStatus: v1alpha1.CSIStatus{},
+		},
+	}
+	return vdoConfig
+}

--- a/controllers/vspherecloudconfig_controller.go
+++ b/controllers/vspherecloudconfig_controller.go
@@ -83,7 +83,7 @@ func (r *VsphereCloudConfigReconciler) Reconcile(ctx context.Context, req ctrl.R
 }
 
 func (r *VsphereCloudConfigReconciler) reconcileVCCredentials(ctx context.Context, config *vdov1alpha1.VsphereCloudConfig) (*vdov1alpha1.VsphereCloudConfig, error) {
-	var vcUser, vcUserPwd, datacenter string
+	var vcUser, vcUserPwd string
 
 	if len(config.Spec.Credentials) > 0 {
 		vcCredsSecret := &v1.Secret{}
@@ -103,12 +103,8 @@ func (r *VsphereCloudConfigReconciler) reconcileVCCredentials(ctx context.Contex
 		vcUserPwd = string(vcCredsSecret.Data["password"])
 	}
 
-	if len(config.Spec.DataCenters) > 0 {
-		datacenter = config.Spec.DataCenters[0]
-	}
-
 	vcIp := config.Spec.VcIP
-	sess, err := session.GetOrCreate(ctx, vcIp, datacenter, vcUser, vcUserPwd, config.Spec.Thumbprint)
+	sess, err := session.GetOrCreate(ctx, vcIp, config.Spec.DataCenters, vcUser, vcUserPwd, config.Spec.Thumbprint)
 	if err != nil {
 		config.Status.Config = vdov1alpha1.VsphereConfigFailed
 		config.Status.Message = fmt.Sprintf("Error establishing session with vcenter %s for user %s", vcIp, vcUser)

--- a/controllers/vspherecloudconfig_controller_test.go
+++ b/controllers/vspherecloudconfig_controller_test.go
@@ -35,11 +35,12 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 )
 
+const (
+	timeout  = time.Second * 10
+	interval = time.Millisecond * 250
+)
+
 var _ = Describe("VsphereCloudConfig controller", func() {
-	const (
-		timeout  = time.Second * 10
-		interval = time.Millisecond * 250
-	)
 
 	Context("When creating vSphereCloudConfig resource", func() {
 		var vc_ip, vc_user, vc_pwd string

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -40,7 +40,7 @@ var sessionMU sync.Mutex
 // Session is a vSphere session with a configured Finder.
 type Session struct {
 	*govmomi.Client
-	datacenters []*object.Datacenter
+	datacenters    []*object.Datacenter
 	VsphereVersion string
 }
 

--- a/pkg/session/session.go
+++ b/pkg/session/session.go
@@ -20,7 +20,9 @@ import (
 	"context"
 	"github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/api/v1alpha1"
 	"net/url"
+	"reflect"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
 	"sync"
 
 	"github.com/pkg/errors"
@@ -38,25 +40,36 @@ var sessionMU sync.Mutex
 // Session is a vSphere session with a configured Finder.
 type Session struct {
 	*govmomi.Client
-	Finder         *find.Finder
-	datacenter     *object.Datacenter
+	datacenters []*object.Datacenter
 	VsphereVersion string
+}
+
+type VirtualMachine struct {
+	*object.VirtualMachine
+	Datacenter *object.Datacenter
 }
 
 // GetOrCreate gets a cached session or creates a new one if one does not
 // already exist.
 func GetOrCreate(
 	ctx context.Context,
-	server, datacenter, username, password string, thumbprint string) (*Session, error) {
+	server string, datacenters []string, username, password, thumbprint string) (*Session, error) {
 	logger := log.FromContext(ctx).WithValues("session", "vcsession")
 	sessionMU.Lock()
 	defer sessionMU.Unlock()
 
-	sessionKey := server + username + datacenter
+	sessionKey := server + username
 	if cachedSession, ok := sessionCache[sessionKey]; ok {
 		if ok, _ := cachedSession.SessionManager.SessionIsActive(ctx); ok {
-			logger.V(2).Info("found active cached vSphere client session", "server", server, "datacenter", datacenter)
-			return &cachedSession, nil
+			logger.V(2).Info("found active cached vSphere client session", "server", server)
+
+			var DCListCachedSession []string
+			for _, dc := range cachedSession.datacenters {
+				DCListCachedSession = append(DCListCachedSession, dc.Name())
+			}
+			if reflect.DeepEqual(datacenters, DCListCachedSession) {
+				return &cachedSession, nil
+			}
 		}
 	}
 
@@ -77,21 +90,26 @@ func GetOrCreate(
 	session := Session{Client: client}
 	session.UserAgent = v1alpha1.GroupVersion.String()
 	// Assign the finder to the session.
-	session.Finder = find.NewFinder(session.Client.Client, false)
+	finder := find.NewFinder(session.Client.Client, false)
 
-	// Assign the datacenter if one was specified.
-	dc, err := session.Finder.DatacenterOrDefault(ctx, datacenter)
-	if err != nil {
-		return nil, errors.Wrapf(err, "unable to find datacenter %q", datacenter)
-	}
-	session.datacenter = dc
-	session.Finder.SetDatacenter(dc)
 	session.VsphereVersion = session.Client.ServiceContent.About.Version
 
-	// Cache the session.
-	sessionCache[sessionKey] = session
+	if len(datacenters) > 0 {
+		for _, datacenter := range datacenters {
 
-	logger.V(2).Info("cached vSphere client session", "server", server, "datacenter", datacenter)
+			// Assign the datacenter if one was specified.
+			dc, err := finder.Datacenter(ctx, datacenter)
+			if err != nil {
+				return nil, errors.Wrapf(err, "unable to find datacenter %q", datacenter)
+			}
+			if dc != nil {
+				session.datacenters = append(session.datacenters, dc)
+			}
+			logger.V(2).Info("cached vSphere client session", "server", server, "datacenter", datacenter)
+		}
+
+	}
+	sessionCache[sessionKey] = session
 
 	return &session, nil
 }
@@ -122,28 +140,22 @@ func newClient(ctx context.Context, url *url.URL, thumbprint string) (*govmomi.C
 	return c, nil
 }
 
-// FindByBIOSUUID finds an object by its BIOS UUID.
-//
-// To avoid comments about this function's name, please see the Golang
-// WIKI https://github.com/golang/go/wiki/CodeReviewComments#initialisms.
-// This function is named in accordance with the example "XMLHTTP".
-func (s *Session) FindByBIOSUUID(ctx context.Context, uuid string) (object.Reference, error) {
-	return s.findByUUID(ctx, uuid, false)
-}
-
-// FindByInstanceUUID finds an object by its instance UUID.
-func (s *Session) FindByInstanceUUID(ctx context.Context, uuid string) (object.Reference, error) {
-	return s.findByUUID(ctx, uuid, true)
-}
-
-func (s *Session) findByUUID(ctx context.Context, uuid string, findByInstanceUUID bool) (object.Reference, error) {
-	if s.Client == nil {
-		return nil, errors.New("vSphere client is not initialized")
+func (s *Session) GetVMByIP(ctx context.Context, ipAddy string) (*VirtualMachine, error) {
+	if len(s.datacenters) > 0 {
+	dcloop:
+		for _, datacenter := range s.datacenters {
+			i := object.NewSearchIndex(datacenter.Client())
+			ipAddy = strings.ToLower(strings.TrimSpace(ipAddy))
+			svm, err := i.FindByIp(ctx, datacenter, ipAddy, true)
+			if err != nil {
+				return nil, err
+			}
+			if svm == nil {
+				continue dcloop
+			}
+			virtualMachine := VirtualMachine{svm.(*object.VirtualMachine), datacenter}
+			return &virtualMachine, nil
+		}
 	}
-	si := object.NewSearchIndex(s.Client.Client)
-	ref, err := si.FindByUuid(ctx, s.datacenter, uuid, true, &findByInstanceUUID)
-	if err != nil {
-		return nil, errors.Wrapf(err, "error finding object by uuid %q", uuid)
-	}
-	return ref, nil
+	return nil, nil
 }

--- a/pkg/session/session_test.go
+++ b/pkg/session/session_test.go
@@ -43,7 +43,7 @@ func TestSession(t *testing.T) {
 
 	authSession, err := GetOrCreate(
 		context.Background(),
-		s.Server.URL, "",
+		s.Server.URL, []string{},
 		s.URL.User.Username(), pass, "")
 	Expect(err).To(BeNil())
 	Expect(authSession).NotTo(BeNil())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> /kind enhancement

**What this PR does / why we need it**:
Earlier, VDO would have tried to configure all the nodes for Cloud Provider irrespective of presence of taints (in case of missing taints, taints would have been added by VDO)
Also, there was no explicit check for nodes availability in the vspherecloudconfig resource.

Going ahead, based on the presence of taints and availability of node in the vsphereCloudConfig resource, VDO would configure CPI for the same.

This PR brings in the following changes:

1. supports multi-datacenter configurations
2. Node availability and taints check based CPI configuration:
    - fetch nodes for Cloud Provider based on Node-uninitialized taint
   - checking the availability of nodes in all vsphereCloudConfig resources configurations for Cloud Provider
   - remove taint reconciler function for adding taints on untainted nodes
   - adding UT for reconciling NodeProviderID and Node Label functions.

Testing Done:
**UT codeCoverage**
```
?       github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator     [no test files]
?       github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/api/v1alpha1        [no test files]
ok      github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/controllers 9.811s  coverage: 39.5% of statements
ok      github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/client  8.638s  coverage: 60.0% of statements
?       github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/context [no test files]
ok      github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/drivers/cpi     1.056s  coverage: 88.0% of statements
ok      github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/drivers/csi     0.657s  coverage: 77.1% of statements
?       github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/models  [no test files]
ok      github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/session 1.066s  coverage: 44.8% of statements


```

**Test Cases**
Case 1:  Testing CPI when Node-uninitialized taint is not present on the node (hostworker in this case). This Node shouldn't be a part of CPI Nodes and hence, CPI should be configured successfully. 

```
kubectl get nodes -A
NAME             STATUS   ROLES                  AGE    VERSION
hostworker       Ready    <none>                 3h7m   v1.22.0
hostworker1      Ready    <none>                 9d     v1.22.0
photon-machine   Ready    control-plane,master   9d     v1.22.0
```
```
kubectl describe vdoconfig -A
Name:         vdoconfig-sample
Namespace:    vmware-system-vdo
Labels:       <none>
Annotations:  <none>
API Version:  vdo.vmware.com/v1alpha1
Kind:         VDOConfig

Spec:
  Cloud Provider:
    Topology:
      Region:  k8s-region
      Zone:    k8s-zone
    Vsphere Cloud Configs:
      10.186.21.100
  Storage Provider:
    Vsphere Cloud Config:  10.186.21.100
Status:
  Cpi:
    nodeStatus :
      hostworker1:       ready
      Photon - Machine:  ready
    Phase:               Configured
  Csi:
    Phase:  Configuring
Events:     <none>
```

Case 2:  Testing CPI when Node-unitialized taint is present on hostworker3 node, but this node is present on different VC and Cloud Provider is not configured for that VC. Hence, it fails with the error "Please check your cloud Provider settings"
```
kubectl get nodes -A
 
hostworker1      Ready    <none>                 10d   v1.22.0
hostworker3      Ready    <none>                 70m   v1.22.0
photon-machine   Ready    control-plane,master   10d   v1.22.0
```


```
kubectl get vdoconfig -A -o yaml

apiVersion: v1
items:
- apiVersion: vdo.vmware.com/v1alpha1
  kind: VDOConfig
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"vdo.vmware.com/v1alpha1","kind":"VDOConfig","metadata":{"annotations":{},"name":"vdoconfig-sample","namespace":"vmware-system-vdo"},"spec":{"cloudProvider":{"topology":{"region":"k8s-region","zone":"k8s-zone"},"vsphereCloudConfigs":["10.186.21.100"]},"storageProvider":{"vsphereCloudConfig":"10.186.21.100"}}}
    creationTimestamp: "2021-08-24T04:13:58Z"
    generation: 5
    name: vdoconfig-sample
    namespace: vmware-system-vdo
    resourceVersion: "10817513"
    uid: 03565ee4-235d-4ab2-8ca6-7fd0ac110d40
  spec:
    cloudProvider:
      topology:
        region: k8s-region
        zone: k8s-zone
      vsphereCloudConfigs:
      - 10.186.21.100
    storageProvider:
      vsphereCloudConfig: 10.186.21.100
  status:
    cpi:
      'nodeStatus ':
        hostworker1: ready
        photon-machine: ready
      phase: Failed
      statusMsg: ' Cloud Provider is not configured to manage the node hostworker3.
        Please check your cloud Provider settings. '
    csi:
      phase: Configuring
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""
```

