### PR TITLE
Add auto-upgrade feature via configMap update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+cover.xml
 bin
 .idea
 api/.DS_Store

--- a/main.go
+++ b/main.go
@@ -93,20 +93,16 @@ func main() {
 		os.Exit(1)
 	}
 
-	vdoConfigReconciler := &controllers.VDOConfigReconciler{
+	if err = (&controllers.VDOConfigReconciler{
 		Client:       mgr.GetClient(),
 		Logger:       ctrllog.Log.WithName("controllers").WithName("VDOConfig"),
 		Scheme:       mgr.GetScheme(),
 		ClientConfig: mgr.GetConfig(),
-	}
-
-	//Start configMap watcher for Compatibility Matrix
-	go vdoConfigReconciler.WatchForConfigMapChanges()
-
-	if err = (vdoConfigReconciler).SetupWithManager(mgr); err != nil {
+	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VDOConfig")
 		os.Exit(1)
 	}
+
 	//+kubebuilder:scaffold:builder
 
 	if err := mgr.AddHealthzCheck("healthz", healthz.Ping); err != nil {

--- a/main.go
+++ b/main.go
@@ -93,12 +93,17 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.VDOConfigReconciler{
+	vdoConfigReconciler := &controllers.VDOConfigReconciler{
 		Client:       mgr.GetClient(),
 		Logger:       ctrllog.Log.WithName("controllers").WithName("VDOConfig"),
 		Scheme:       mgr.GetScheme(),
 		ClientConfig: mgr.GetConfig(),
-	}).SetupWithManager(mgr); err != nil {
+	}
+
+	//Start configMap watcher for Compatibility Matrix
+	go vdoConfigReconciler.WatchForConfigMapChanges()
+
+	if err = (vdoConfigReconciler).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "VDOConfig")
 		os.Exit(1)
 	}


### PR DESCRIPTION
**What type of PR is this?**
> /kind enhancement

**What this PR does / why we need it**:
This PR adds the support of upgrade scenario where user can update the versions of CPI/CSI without restarting the vdo-controller. 
User need to update the configMap which contains the upgraded version Matrix, and VDO will dynamically listen to any change in the configMap and apply the changes accordingly.

**Which issue(s) this PR fixes**:
Fixes #5 

**Test Report Added?**:
> /kind TESTED

**Special notes for your reviewer**:
 - [x] addition of UT in Progress