### PR TITLE
Added Unit Test for CheckCompatAndRetrieveSpec function

### DIFF
--- a/controllers/vdoconfig_controller_test.go
+++ b/controllers/vdoconfig_controller_test.go
@@ -18,8 +18,14 @@ package controllers
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	dynclient "github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/client"
+	"github.com/vmware/govmomi/simulator"
+	"k8s.io/apimachinery/pkg/version"
+	restclient "k8s.io/client-go/rest"
+	"net/http"
+	"net/http/httptest"
 	"os"
 
 	. "github.com/onsi/ginkgo"
@@ -1094,6 +1100,124 @@ var _ = Describe("TestGetMatrixConfig", func() {
 			Expect(err).To(HaveOccurred())
 		})
 
+	})
+})
+
+var _ = Describe("TestCheckCompatAndRetrieveSpec", func() {
+
+	Context("When fetching deployment yamls", func() {
+		RegisterFailHandler(Fail)
+		ctx := context.Background()
+
+		var sim *simulator.Server
+		var vc_user, vc_pwd string
+
+		s := scheme.Scheme
+		s.AddKnownTypes(v1alpha1.GroupVersion, &v1alpha1.VDOConfig{})
+
+		clientSet := fake.NewSimpleClientset()
+		Expect(clientSet).NotTo(BeNil())
+
+		expect := version.Info{
+			Major:     "1",
+			Minor:     "21",
+			GitCommit: "v1.21.1",
+		}
+		// get server object with expected version info
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, req *http.Request) {
+			output, err := json.Marshal(expect)
+			Expect(err).NotTo(HaveOccurred())
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(output)
+			Expect(err).NotTo(HaveOccurred())
+		}))
+
+		r := VDOConfigReconciler{
+			Client:       fake2.NewClientBuilder().WithRuntimeObjects().Build(),
+			Logger:       ctrllog.Log.WithName("VDOConfigControllerTest"),
+			Scheme:       s,
+			ClientConfig: &restclient.Config{Host: server.URL},
+		}
+
+		vdoctx := vdocontext.VDOContext{
+			Context: ctx,
+			Logger:  r.Logger,
+		}
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      "test-resource",
+				Namespace: "default",
+			},
+		}
+
+		SessionFn = func(ctx context.Context,
+			server string, datacenters []string, username, password, thumbprint string) (*session.Session, error) {
+			return &session.Session{
+				Client:         nil,
+				Datacenters:    nil,
+				VsphereVersion: "7.0.3",
+			}, nil
+
+		}
+
+		matrixString := "{\n    \"CSI\" : {\n            \"2.2.1\" : {\n                    \"vSphere\" : { \"min\" : \"6.7.0\", \"max\": \"7.0.7\"},\n                    \"k8s\" : {\"min\": \"1.18\", \"max\": \"1.21\"},\n                    \"isCPIRequired\" : false,\n                    \"deploymentPath\": [\n                    \"https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/v2.2.1/manifests/v2.2.1/rbac/vsphere-csi-controller-rbac.yaml\",\n                    \"https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/v2.2.1/manifests/v2.2.1/rbac/vsphere-csi-node-rbac.yaml\",\n                    \"https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/v2.2.1/manifests/v2.2.1/deploy/vsphere-csi-controller-deployment.yaml\",\n                    \"https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/v2.2.1/manifests/v2.2.1/deploy/vsphere-csi-node-ds.yaml\"]\n                    }\n        },\n    \"CPI\" : {\n            \"1.20.0\" : {\n                    \"vSphere\" : { \"min\" : \"6.7.0\", \"max\": \"7.0.7\"},\n                    \"k8s\" : {\"skewVersion\": \"1.21\"},\n                    \"deploymentPath\": [\n                    \"https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/v1.20.0/manifests/controller-manager/cloud-controller-manager-roles.yaml\",\n                    \"https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/v1.20.0/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml\",\n                    \"https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/v1.20.0/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml\"]\n                    }\n        }\n             \n}"
+
+		vdoConfig := initializeVDOConfig()
+		Expect(r.Create(vdoctx, vdoConfig)).Should(Succeed())
+
+		//Setup VC SIM
+		model := simulator.VPX()
+		model.Host = 0 // ClusterHost only
+
+		defer model.Remove()
+		err := model.Create()
+		if err != nil {
+			Expect(err).NotTo(HaveOccurred())
+		}
+		model.Service.TLS = new(tls.Config)
+
+		sim = model.Service.NewServer()
+		vc_pwd, _ = sim.URL.User.Password()
+		vc_user = sim.URL.User.Username()
+
+		It("should create the resources without error", func() {
+
+			secret := &v12.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "secret-ref",
+					Namespace: "kube-system",
+				},
+				Data: map[string][]byte{
+					"username": []byte(vc_user),
+					"password": []byte(vc_pwd),
+				},
+			}
+			Expect(r.Create(ctx, secret)).Should(Succeed())
+
+			cloudConfig := &v1alpha1.VsphereCloudConfig{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-resource",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.VsphereCloudConfigSpec{
+					VcIP:        "1.1.1.1",
+					Insecure:    true,
+					Credentials: "secret-ref",
+					DataCenters: []string{"datacenter-1"},
+				},
+				Status: v1alpha1.VsphereCloudConfigStatus{},
+			}
+			Expect(r.Create(ctx, cloudConfig)).Should(Succeed())
+			defer sim.Close()
+		})
+
+		It("Should fetch deployment yamls without error", func() {
+			err := r.CheckCompatAndRetrieveSpec(vdoctx, req, vdoConfig, matrixString)
+			Expect(err).NotTo(HaveOccurred())
+			defer server.Close()
+		})
 	})
 })
 

--- a/controllers/vspherecloudconfig_controller_test.go
+++ b/controllers/vspherecloudconfig_controller_test.go
@@ -73,7 +73,7 @@ var _ = Describe("VsphereCloudConfig controller", func() {
 
 			cloudConfig := v1alpha1.VsphereCloudConfig{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-resource",
+					Name:      "test-resource1",
 					Namespace: "default",
 				},
 				Spec: v1alpha1.VsphereCloudConfigSpec{
@@ -87,7 +87,7 @@ var _ = Describe("VsphereCloudConfig controller", func() {
 			Expect(k8sClient.Create(ctx, &cloudConfig)).Should(Succeed())
 			config := v1alpha1.VsphereCloudConfig{}
 			Eventually(func() bool {
-				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "test-resource"}, &config)
+				err := k8sClient.Get(ctx, types.NamespacedName{Namespace: "default", Name: "test-resource1"}, &config)
 				return err == nil
 			}, timeout, interval).Should(BeTrue())
 			Expect(config.Spec.VcIP).Should(Equal("1.1.1.1"))
@@ -98,7 +98,7 @@ var _ = Describe("VsphereCloudConfig controller", func() {
 
 			cloudConfig := &v1alpha1.VsphereCloudConfig{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "test-resource",
+					Name:      "test-resource1",
 					Namespace: "default",
 				},
 				Spec: v1alpha1.VsphereCloudConfigSpec{
@@ -133,7 +133,7 @@ var _ = Describe("VsphereCloudConfig controller", func() {
 
 			req := reconcile.Request{
 				NamespacedName: types.NamespacedName{
-					Name:      "test-resource",
+					Name:      "test-resource1",
 					Namespace: "default",
 				},
 			}
@@ -145,7 +145,7 @@ var _ = Describe("VsphereCloudConfig controller", func() {
 
 			config := v1alpha1.VsphereCloudConfig{}
 			Eventually(func() v1alpha1.ConfigStatus {
-				err := client.Get(ctx, types.NamespacedName{Namespace: "default", Name: "test-resource"}, &config)
+				err := client.Get(ctx, types.NamespacedName{Namespace: "default", Name: "test-resource1"}, &config)
 				if err != nil {
 					return ""
 				}


### PR DESCRIPTION
**What type of PR is this?**
 /kind enhancement

This PR brings in the following change :
Unit test for CheckCompatAndRetrieveSpec function which fetches vSphere Version and k8s Version, then fetches the compatible versions of CSI and CPI.

**Test Report :**

```
?       github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator     [no test files]
?       github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/api/v1alpha1        [no test files]
ok      github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/controllers 12.379s coverage: 47.6% of statements
ok      github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/client  10.506s coverage: 50.7% of statements
?       github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/context [no test files]
ok      github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/drivers/cpi     0.393s  coverage: 88.0% of statements
ok      github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/drivers/csi     0.754s  coverage: 77.1% of statements
?       github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/models  [no test files]
ok      github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/session 0.928s  coverage: 44.8% of statements

```