### PR TITLE
add vdo deploy cmd

### DIFF
--- a/vdoctl/cmd/deploy.go
+++ b/vdoctl/cmd/deploy.go
@@ -16,33 +16,62 @@ limitations under the License.
 package cmd
 
 import (
+	"context"
 	"fmt"
-
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	dynclient "github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/client"
+	vdocontext "github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/context"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"strings"
 )
+
+type platform string
+
+const (
+	openshift platform = "openshift"
+)
+
+var specfile string
 
 // deployCmd represents the deploy command
 var deployCmd = &cobra.Command{
-	Use:   "deploy",
+	Use:   "deploy --spec <path to spec file> (can be http or file based url's)",
 	Short: "Deploy vSphere Kubernetes Driver Operator",
-	Long: `This command helps to deploy VDO on the target kubernetes cluster
-referenced by the KUBECONFIG environment. VDO deployment spec is downloaded and installed 
-on the kubernetes cluster`,
+	Long: `This command helps to deploy VDO on the kubernetes cluster targeted by --kubeconfig flag or KUBECONFIG environment variable.
+Currently the command supports deployment on vanilla k8s cluster`,
 	Run: func(cmd *cobra.Command, args []string) {
-		fmt.Println("deploy called")
+		var err error
+		var fileBytes []byte
+
+		ctx := vdocontext.VDOContext{
+			Context: context.Background(),
+			Logger:  ctrllog.Log.WithName("vdoctl:deploy"),
+		}
+
+		k8sPlatform := "" // promptGetSelect([]string{"vanilla", "openshift"}, "Please select the flavour of your k8s cluster")
+		//todo need to add suppport for openshift clusters.
+		if k8sPlatform == string(openshift) {
+			panic(errors.New("Deploy command does not support openshift cluster at the moment"))
+		}
+
+		if strings.Contains(specfile, "file://") {
+			fileBytes, err = dynclient.GenerateYamlFromFilePath(specfile)
+		} else {
+			fileBytes, err = dynclient.GenerateYamlFromUrl(specfile)
+		}
+		if err != nil {
+			cobra.CheckErr(fmt.Sprintf("unable to read deployment spec from %s", specfile))
+		}
+
+		_, applyErr := dynclient.ParseAndProcessK8sObjects(ctx, K8sClient, fileBytes, "")
+		if applyErr != nil {
+			cobra.CheckErr(applyErr)
+		}
 	},
 }
 
 func init() {
+	deployCmd.Flags().StringVar(&specfile, "spec", "", "url to vdo deployment spec file")
 	rootCmd.AddCommand(deployCmd)
-
-	// Here you will define your flags and configuration settings.
-
-	// Cobra supports Persistent Flags which will work for this command
-	// and all subcommands, e.g.:
-	// deployCmd.PersistentFlags().String("foo", "", "A help for foo")
-
-	// Cobra supports local flags which will only run when this command
-	// is called directly, e.g.:
-	// deployCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
 }

--- a/vdoctl/cmd/root.go
+++ b/vdoctl/cmd/root.go
@@ -102,8 +102,6 @@ func initConfig() {
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
 
-	fmt.Printf("kubeconfig value is %s", kubeconfig)
-
 	if len(kubeconfig) <= 0 {
 		kubeconfig = os.Getenv("KUBECONFIG")
 		if len(kubeconfig) <= 0 {

--- a/vdoctl/cmd/root.go
+++ b/vdoctl/cmd/root.go
@@ -16,14 +16,37 @@ limitations under the License.
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"github.com/spf13/cobra"
+	"github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/api/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/clientcmd"
 	"os"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/spf13/viper"
 )
 
-var cfgFile string
+const (
+	VdoNamespace = "vmware-system-vdo"
+	GroupName    = "vdo.vmware.com"
+	GroupVersion = "v1alpha1"
+)
+
+var (
+	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: GroupVersion}
+	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
+	AddToScheme        = SchemeBuilder.AddToScheme
+	cfgFile            string
+	kubeconfig         string
+	K8sClientset       *kubernetes.Clientset
+	K8sClient          client.Client
+)
 
 // rootCmd represents the base command when called without any subcommands
 var rootCmd = &cobra.Command{
@@ -51,15 +74,9 @@ func Execute() {
 func init() {
 	cobra.OnInitialize(initConfig)
 
-	// Here you will define your flags and configuration settings.
-	// Cobra supports persistent flags, which, if defined here,
-	// will be global for your application.
-
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.vdoctl.yaml)")
 
-	// Cobra also supports local flags, which will only run
-	// when this action is called directly.
-	rootCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+	rootCmd.PersistentFlags().StringVar(&kubeconfig, "kubeconfig", "", "points to the kubeconfig file of the target k8s cluster")
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -84,4 +101,54 @@ func initConfig() {
 	if err := viper.ReadInConfig(); err == nil {
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
+
+	fmt.Printf("kubeconfig value is %s", kubeconfig)
+
+	if len(kubeconfig) <= 0 {
+		kubeconfig = os.Getenv("KUBECONFIG")
+		if len(kubeconfig) <= 0 {
+			cobra.CheckErr(errors.New("could not detect a target kubernetes cluster. " +
+				"Either use --kubeconfig flag or set KUBECONFIG environment variable"))
+		}
+	}
+
+	err := generateK8sClient(kubeconfig)
+	if err != nil {
+		cobra.CheckErr(err)
+	}
+
+}
+
+func generateK8sClient(kubeconfig string) error {
+	clientConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	if err != nil {
+		return errors.New("Failed to generate client from provided kubeconfig")
+	}
+
+	K8sClientset, err = kubernetes.NewForConfig(clientConfig)
+	if err != nil {
+		return err
+	}
+
+	K8sClient, _ = client.New(clientConfig, client.Options{
+		Scheme: scheme.Scheme,
+	})
+
+	err = AddToScheme(scheme.Scheme)
+	if err != nil {
+		return err
+	}
+
+	return nil
+
+}
+
+func addKnownTypes(scheme *runtime.Scheme) error {
+	scheme.AddKnownTypes(SchemeGroupVersion,
+		&v1alpha1.VsphereCloudConfig{},
+		&v1alpha1.VsphereCloudConfigList{},
+		&v1alpha1.VDOConfig{},
+	)
+	metav1.AddToGroupVersion(scheme, SchemeGroupVersion)
+	return nil
 }


### PR DESCRIPTION
**What type of PR is this?**

 /kind enhancement

**What this PR does / why we need it**:
This brings in code changes to deploy vdo on vanilla k8s cluster through vdoctl CLI

**Test Report Added?**:
 /kind TESTED

**Test Report**:
```./bin/vdoctl deploy --help
This command helps to deploy VDO on the kubernetes cluster targeted by --kubeconfig flag or KUBECONFIG environment variable.
Currently the command supports deployment on vanilla k8s cluster

Usage:
  vdoctl deploy --spec <path to spec file> (can be http or file based url's) [flags]

Flags:
  -h, --help          help for deploy
      --spec string   url to vdo deployment spec file

Global Flags:
      --config string       config file (default is $HOME/.vdoctl.yaml)
      --kubeconfig string   points to the kubeconfig file of the target k8s cluster
```

```
bin/vdoctl deploy --kubeconfig ./kind-kubeconfig --spec https://raw.githubusercontent.com/jvrahav/docs/main/vdo-spec.yaml
```