### PR TITLE
Add update cmd to vdoctl

### DIFF
--- a/.github/workflows/BuildAndDeploy.yml
+++ b/.github/workflows/BuildAndDeploy.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Build and Deploy
         run: make deploy
 
+      - name: Build vdoctl
+        run: make build-vdoctl
+
       # Need to enable the billing in CodeCov
       - name : Upload CodeCoverage to Codecov
         uses: codecov/codecov-action@v2

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 cover.xml
+kind-kubeconfig
 bin
 .idea
 api/.DS_Store

--- a/vdoctl/cmd/update.go
+++ b/vdoctl/cmd/update.go
@@ -1,0 +1,43 @@
+/*
+Copyright © 2021
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+)
+
+// updateCmd represents the update command
+var updateCmd = &cobra.Command{
+	Use:     "update",
+	Aliases: []string{"u"},
+	Short:   "Update the VDO Resources",
+	Long: `This command helps to update the VDO Resources which is created by VDO Controller. 
+For example:
+
+vdoctl update matrix https://sample/sample.yaml
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		fmt.Println("Please select the sub-command, to get more help run" +
+			"vdoctl update -h")
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(updateCmd)
+
+}

--- a/vdoctl/cmd/update_matrix.go
+++ b/vdoctl/cmd/update_matrix.go
@@ -77,7 +77,7 @@ func updateConfigMap(filepath string, ctx context.Context) error {
 		Name:      CompatMatrixConfigMap,
 	}
 
-	if strings.Contains(filepath, "https://") || strings.Contains(filepath, "http://") {
+	if strings.HasPrefix(filepath, "https://") || strings.HasPrefix(filepath, "http://") {
 		data = map[string]string{"versionConfigURL": filepath, "auto-upgrade": "disabled"}
 	} else {
 		fileBytes, err := vdoClient.GenerateYamlFromFilePath(filepath)

--- a/vdoctl/cmd/update_matrix.go
+++ b/vdoctl/cmd/update_matrix.go
@@ -1,0 +1,104 @@
+/*
+Copyright © 2021
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"context"
+	"fmt"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"strings"
+
+	"github.com/spf13/cobra"
+	vdoClient "github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/client"
+)
+
+var CompatMatrixConfigMap = "compat-matrix-config"
+
+// matrixUpdateCmd represents the driver command
+var matrixUpdateCmd = &cobra.Command{
+	Use:     "matrix",
+	Aliases: []string{"cm"},
+	Short:   "A brief description of your command",
+	Long: `This command helps to update the Compatibility matrix of Drivers, 
+which in turns help to upgrade/downgrade the versions of CSI & CPI drivers.
+For Example : 
+vdoctl update matrix https://github.com/demo/demo.yaml
+vdoctl update matrix file://var/sample/sample.yaml
+
+`,
+	Run: func(cmd *cobra.Command, args []string) {
+		cobra.MinimumNArgs(1)
+		updateMatrix(cmd, args)
+	},
+}
+
+// updateMatrix updates the ConfigMap containing the compatibility-matrix
+func updateMatrix(cmd *cobra.Command, args []string) {
+
+	if len(args) < 1 {
+		cobra.CheckErr("At-least one argument should be provided")
+	}
+
+	updatedMatrix := args[0]
+	ctxNew := context.Background()
+
+	//TODO Check for FileShare Volumes and prompt an error if any
+
+	err := updateConfigMap(updatedMatrix, ctxNew)
+
+	if err != nil {
+		cobra.CheckErr(fmt.Sprintf("unable to read the updated matrix from %s", updatedMatrix))
+	}
+}
+
+func updateConfigMap(filepath string, ctx context.Context) error {
+
+	var err error
+	var data map[string]string
+
+	configMetaData := types.NamespacedName{
+		Namespace: VdoNamespace,
+		Name:      CompatMatrixConfigMap,
+	}
+
+	if strings.Contains(filepath, "https://") || strings.Contains(filepath, "http://") {
+		data = map[string]string{"versionConfigURL": filepath, "auto-upgrade": "disabled"}
+	} else {
+		fileBytes, err := vdoClient.GenerateYamlFromFilePath(filepath)
+		if err != nil {
+			cobra.CheckErr(fmt.Sprintf("unable to read the updated matrix from %s", filepath))
+		}
+		data = map[string]string{"versionConfigContent": string(fileBytes), "auto-upgrade": "disabled"}
+	}
+
+	configMapObj := metav1.ObjectMeta{Name: configMetaData.Name, Namespace: configMetaData.Namespace}
+	vsphereConfigMap := v1.ConfigMap{Data: data, ObjectMeta: configMapObj}
+
+	err = K8sClient.Update(ctx, &vsphereConfigMap, &client.UpdateOptions{})
+
+	if err != nil {
+		cobra.CheckErr(fmt.Sprintf("Error received in updating config Map  %s", err))
+	}
+	return err
+}
+
+func init() {
+	// Add the sub-command 'matrix' to update command
+	updateCmd.AddCommand(matrixUpdateCmd)
+}


### PR DESCRIPTION
**What type of PR is this?**
 /kind enhancement

**What this PR does / why we need it**:
This PR adds the update command to vdoctl.

**Which issue(s) this PR fixes**:
Fixes #32 

**Test Report Added?**:
 /kind TESTED

**Test Report**:
Basic Usage
```
smohammadasi@smohammadas-a01 bin % vdoctl update -h                                                                                            
This command helps to update the VDO Resources which is created by VDO Controller. 
For example:

vdoctl update matrix https://sample/sample.yaml

Usage:
  vdoctl update [flags]
  vdoctl update [command]

Aliases:
  update, u

Available Commands:
  matrix      A brief description of your command

Flags:
  -h, --help   help for update

Global Flags:
      --config string       config file (default is $HOME/.vdoctl.yaml)
      --kubeconfig string   points to the kubeconfig file of the target k8s cluster

Use "vdoctl update [command] --help" for more information about a command.


smohammadasi@smohammadas-a01 bin % vdoctl update matrix -h
This command helps to update the Compatibility matrix of Drivers, 
which in turns help to upgrade/downgrade the versions of CSI & CPI drivers.
For Example : 
vdoctl update matrix https://github.com/demo/demo.yaml
vdoctl update matrix file://var/sample/sample.yaml

Usage:
  vdoctl update matrix [flags]

Aliases:
  matrix, cm

Flags:
  -h, --help   help for matrix

Global Flags:
      --config string       config file (default is $HOME/.vdoctl.yaml)
      --kubeconfig string   points to the kubeconfig file of the target k8s cluster
```

Usage with no params
```
smohammadasi@smohammadas-a01 bin % vdoctl update matrix   
Error: At-least one argument should be provided

```

Usage with Network URL
```
smohammadasi@smohammadas-a01 bin % vdoctl update matrix http://sample.yaml

smohammadasi@smohammadas-a01 bin % k describe cm -n vmware-system-vdo compat-matrix-config                                                 
Name:         compat-matrix-config
Namespace:    vmware-system-vdo
Labels:       <none>
Annotations:  <none>

Data
====
auto-upgrade:
----
disabled
versionConfigURL:
----
http://sample.yaml
Events:  <none>

```
Usage with Local Files
```
smohammadasi@smohammadas-a01 bin % vdoctl update matrix file://Users/smohammadasi/go/src/github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/vdoctl/test.yaml 

smohammadasi@smohammadas-a01 bin % k describe cm -n vmware-system-vdo compat-matrix-config                                                                           
Name:         compat-matrix-config
Namespace:    vmware-system-vdo
Labels:       <none>
Annotations:  <none>

Data
====
auto-upgrade:
----
disabled
versionConfigContent:
----
{
asif: "test"
}

Events:  <none>

```

Usage with Aliases
```
vdoctl u cm file://test.yaml 
vdoctl u cm http://sample.yaml
```

**Special notes for your reviewer**:
Logic to check the fileshare volumes will be discussed with CSI folks and then we will add the check accordingly