### PR TITLE
Add vdoctl version command to get corresponding VDO, vSphere, k8s, CSI and CPI Version

### DIFF
--- a/artifacts/vanilla/vdo-spec.yaml
+++ b/artifacts/vanilla/vdo-spec.yaml
@@ -59,8 +59,6 @@ spec:
                     items:
                       type: string
                     type: array
-                required:
-                - vsphereCloudConfigs
                 type: object
               storageProvider:
                 description: StorageProvider refers to the section of config that is required to configure CSI driver
@@ -303,6 +301,7 @@ rules:
   - configmaps
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -313,6 +312,7 @@ rules:
   resources:
   - nodes
   verbs:
+  - delete
   - get
   - list
   - patch
@@ -323,6 +323,7 @@ rules:
   resources:
   - pods
   verbs:
+  - delete
   - get
   - list
   - watch
@@ -332,6 +333,7 @@ rules:
   - secrets
   verbs:
   - create
+  - delete
   - get
   - list
   - update
@@ -342,6 +344,7 @@ rules:
   - serviceaccounts
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -352,6 +355,7 @@ rules:
   - services
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -362,6 +366,7 @@ rules:
   - daemonsets
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -372,6 +377,7 @@ rules:
   - deployments
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -650,7 +656,7 @@ spec:
             configMapKeyRef:
               key: auto-upgrade
               name: compat-matrix-config
-        image: vmware.com/vdo:061532d
+        image: vmware.com/vdo:d6a761e
         imagePullPolicy: IfNotPresent
         livenessProbe:
           httpGet:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -18,4 +18,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: vmware.com/vdo
-  newTag: bac1975
+  newTag: d6a761e

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -12,6 +12,7 @@ rules:
   - configmaps
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -22,6 +23,7 @@ rules:
   resources:
   - nodes
   verbs:
+  - delete
   - get
   - list
   - patch
@@ -32,6 +34,7 @@ rules:
   resources:
   - pods
   verbs:
+  - delete
   - get
   - list
   - watch
@@ -41,6 +44,7 @@ rules:
   - secrets
   verbs:
   - create
+  - delete
   - get
   - list
   - update
@@ -51,6 +55,7 @@ rules:
   - serviceaccounts
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -61,6 +66,7 @@ rules:
   - services
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -71,6 +77,7 @@ rules:
   - daemonsets
   verbs:
   - create
+  - delete
   - get
   - list
   - patch
@@ -81,6 +88,7 @@ rules:
   - deployments
   verbs:
   - create
+  - delete
   - get
   - list
   - patch

--- a/controllers/vdoconfig_controller.go
+++ b/controllers/vdoconfig_controller.go
@@ -433,12 +433,6 @@ func (r *VDOConfigReconciler) reconcileCSIConfiguration(vdoctx vdocontext.VDOCon
 		return ctrl.Result{}, err
 	}
 
-	err = r.updateCSIPhase(vdoctx, vdoConfig, vdov1alpha1.Configuring, "")
-	if err != nil {
-		r.updateCSIStatusForError(vdoctx, err, vdoConfig, "Error in updating CSI phase")
-		return ctrl.Result{}, err
-	}
-
 	vdoctx.Logger.V(4).Info("reconciling deployment for CSI")
 	updateStatus, err := r.reconcileCSIDeployment(vdoctx)
 	if err != nil {

--- a/controllers/vdoconfig_controller_test.go
+++ b/controllers/vdoconfig_controller_test.go
@@ -807,12 +807,12 @@ var _ = Describe("TestfetchDeploymentYamls", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		It("should fetch CSI deployment yamls without error", func() {
-			err = r.fetchCsiDeploymentYamls(vdoctx, matrix, []string{"7.0.3"}, "1.21")
+			err = r.FetchCsiDeploymentYamls(vdoctx, matrix, []string{"7.0.3"}, "1.21")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should fetch CPI deployment yamls without error", func() {
-			err = r.fetchCpiDeploymentYamls(vdoctx, matrix, []string{"7.0.3"}, "1.21")
+			err = r.FetchCpiDeploymentYamls(vdoctx, matrix, []string{"7.0.3"}, "1.21")
 			Expect(err).NotTo(HaveOccurred())
 		})
 	})
@@ -842,12 +842,12 @@ var _ = Describe("TestfetchDeploymentYamls", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		It("should fetch CSI deployment yamls with error", func() {
-			err = r.fetchCsiDeploymentYamls(vdoctx, matrix, []string{"7.0.3"}, "1.21")
+			err = r.FetchCsiDeploymentYamls(vdoctx, matrix, []string{"7.0.3"}, "1.21")
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should fetch CPI deployment yamls with error", func() {
-			err = r.fetchCpiDeploymentYamls(vdoctx, matrix, []string{"7.0.3"}, "1.21")
+			err = r.FetchCpiDeploymentYamls(vdoctx, matrix, []string{"7.0.3"}, "1.21")
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -877,12 +877,12 @@ var _ = Describe("TestfetchDeploymentYamls", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		It("should fetch CSI deployment yamls with error", func() {
-			err = r.fetchCsiDeploymentYamls(vdoctx, matrix, []string{"7.0.3"}, "1.22")
+			err = r.FetchCsiDeploymentYamls(vdoctx, matrix, []string{"7.0.3"}, "1.22")
 			Expect(err).To(HaveOccurred())
 		})
 
 		It("should fetch CPI deployment yamls with error", func() {
-			err = r.fetchCpiDeploymentYamls(vdoctx, matrix, []string{"7.0.3"}, "1.22")
+			err = r.FetchCpiDeploymentYamls(vdoctx, matrix, []string{"7.0.3"}, "1.22")
 			Expect(err).To(HaveOccurred())
 		})
 	})
@@ -912,12 +912,12 @@ var _ = Describe("TestfetchDeploymentYamls", func() {
 		Expect(err).NotTo(HaveOccurred())
 
 		It("should fetch CSI deployment yamls without error", func() {
-			err = r.fetchCsiDeploymentYamls(vdoctx, matrix, []string{"6.5.3"}, "1.17")
+			err = r.FetchCsiDeploymentYamls(vdoctx, matrix, []string{"6.5.3"}, "1.17")
 			Expect(err).NotTo(HaveOccurred())
 		})
 
 		It("should fetch CPI deployment yamls without error", func() {
-			err = r.fetchCpiDeploymentYamls(vdoctx, matrix, []string{"6.5.3"}, "1.17")
+			err = r.FetchCpiDeploymentYamls(vdoctx, matrix, []string{"6.5.3"}, "1.17")
 			Expect(err).NotTo(HaveOccurred())
 		})
 

--- a/vdoctl/cmd/root.go
+++ b/vdoctl/cmd/root.go
@@ -26,6 +26,7 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -47,6 +48,7 @@ var (
 	kubeconfig         string
 	K8sClientset       *kubernetes.Clientset
 	K8sClient          client.Client
+	ClientConfig       *rest.Config
 )
 
 // rootCmd represents the base command when called without any subcommands
@@ -128,17 +130,18 @@ func initConfig() {
 }
 
 func generateK8sClient(kubeconfig string) error {
-	clientConfig, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+	var err error
+	ClientConfig, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
 	if err != nil {
 		return errors.New("Failed to generate client from provided kubeconfig")
 	}
 
-	K8sClientset, err = kubernetes.NewForConfig(clientConfig)
+	K8sClientset, err = kubernetes.NewForConfig(ClientConfig)
 	if err != nil {
 		return err
 	}
 
-	K8sClient, _ = client.New(clientConfig, client.Options{
+	K8sClient, _ = client.New(ClientConfig, client.Options{
 		Scheme: scheme.Scheme,
 	})
 

--- a/vdoctl/cmd/version.go
+++ b/vdoctl/cmd/version.go
@@ -1,0 +1,165 @@
+/*
+Copyright 2021.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"github.com/spf13/cobra"
+	vdov1alpha1 "github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/api/v1alpha1"
+	"github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/controllers"
+	dynclient "github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/client"
+	vdocontext "github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/context"
+	v12 "k8s.io/api/apps/v1"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/kubernetes/scheme"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"strings"
+)
+
+const (
+	VdoDeploymentName = "vdo-controller-manager"
+)
+
+// versionCmd represents the version command
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "command to get VDO version",
+	Long: `This command helps to get the version of the configurations created by VDO.
+            It includes brief detail about the version of CloudProvider and StorageProvider
+             along with VC and Kubernetes details`,
+	Run: func(cmd *cobra.Command, args []string) {
+
+		var vdoConfigList vdov1alpha1.VDOConfigList
+
+		ctx := vdocontext.VDOContext{
+			Context: context.Background(),
+			Logger:  ctrllog.Log.WithName("vdoctl:version"),
+		}
+
+		err := K8sClient.List(ctx, &vdoConfigList)
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+
+		s := scheme.Scheme
+		s.AddKnownTypes(vdov1alpha1.GroupVersion, &vdov1alpha1.VDOConfig{})
+
+		r := controllers.VDOConfigReconciler{
+			Client:       K8sClient,
+			Logger:       ctrllog.Log.WithName("vdoctl:version"),
+			Scheme:       s,
+			ClientConfig: ClientConfig,
+		}
+
+		req := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      CompatMatrixConfigMAp,
+				Namespace: VdoNamespace,
+			},
+		}
+
+		deploymentReq := reconcile.Request{
+			NamespacedName: types.NamespacedName{
+				Name:      VdoDeploymentName,
+				Namespace: VdoNamespace,
+			},
+		}
+
+		// Fetch VDO deployment object
+		deployment := &v12.Deployment{}
+		err = K8sClient.Get(ctx, deploymentReq.NamespacedName, deployment)
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+
+		var deploymentData string
+
+		for _, v := range deployment.Annotations {
+			if strings.Contains(v, "image") {
+				deploymentData = v
+				break
+			}
+		}
+
+		var deploymentMap map[string]interface{}
+		if err = json.Unmarshal([]byte(deploymentData), &deploymentMap); err != nil {
+			cobra.CheckErr(err)
+		}
+
+		containerInfo := deploymentMap["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["containers"].([]interface{})
+
+		var count int
+		for i, container := range containerInfo {
+			if container.(map[string]interface{})["name"] == "manager" {
+				count = i
+			}
+		}
+
+		imageName := containerInfo[count].(map[string]interface{})["image"]
+
+		vdoVersion := strings.Split(fmt.Sprint(imageName), ":")
+
+		fmt.Printf("VDO Version        : %s", vdoVersion[len(vdoVersion)-1])
+
+		configMap := &v1.ConfigMap{}
+		err = K8sClient.Get(ctx, req.NamespacedName, configMap)
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+
+		matrixConfig, err := dynclient.ParseMatrixYaml(configMap.Data["versionConfigURL"])
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+
+		vSphereVersion, _ := r.FetchVsphereVersions(ctx, req, &vdoConfigList.Items[0])
+		fmt.Printf("\nvSphere Versions   : %s", vSphereVersion)
+
+		k8sVersion, _ := r.Fetchk8sVersions(ctx)
+		fmt.Printf("\nkubernetes Version : %s", k8sVersion)
+
+		err = r.FetchCpiDeploymentYamls(ctx, matrixConfig, vSphereVersion, k8sVersion)
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+
+		err = r.FetchCsiDeploymentYamls(ctx, matrixConfig, vSphereVersion, k8sVersion)
+		if err != nil {
+			cobra.CheckErr(err)
+		}
+		fmt.Printf("\nCSI Version        : %s", r.CurrentCSIDeployedVersion)
+
+		fmt.Printf("\nCPI Version        : %s", r.CurrentCPIDeployedVersion)
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+
+	// Here you will define your flags and configuration settings.
+
+	// Cobra supports Persistent Flags which will work for this command
+	// and all subcommands, e.g.:
+	// deployCmd.PersistentFlags().String("foo", "", "A help for foo")
+
+	// Cobra supports local flags which will only run when this command
+	// is called directly, e.g.:
+	// deployCmd.Flags().BoolP("toggle", "t", false, "Help message for toggle")
+}

--- a/vdoctl/cmd/version.go
+++ b/vdoctl/cmd/version.go
@@ -105,14 +105,13 @@ var versionCmd = &cobra.Command{
 
 		containerInfo := deploymentMap["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["containers"].([]interface{})
 
-		var count int
+		var imageName interface{}
 		for i, container := range containerInfo {
 			if container.(map[string]interface{})["name"] == "manager" {
-				count = i
+				imageName = containerInfo[i].(map[string]interface{})["image"]
+				break
 			}
 		}
-
-		imageName := containerInfo[count].(map[string]interface{})["image"]
 
 		vdoVersion := strings.Split(fmt.Sprint(imageName), ":")
 


### PR DESCRIPTION
**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:

This PR brings in the following changes : 
Fetch the corresponding VDO, vSphere, Kubernetes, CSI and CPI Version using command line utility.

**Test Report Added?**:
> /kind TESTED

**Test Report**:

```
 bin/vdoctl version              
VDO Version        : 4144c7a
vSphere Versions   : [7.0.3]
kubernetes Version : 1.21
CSI Version        : 2.2.1
CPI Version        : 1.20.0                            
```
<img width="595" alt="vdoctl version" src="https://user-images.githubusercontent.com/88429350/135712333-d8a4e825-8b0e-489b-bcb1-11e1b3f0ce9e.png">

 ```
kubectl get vspherecloudconfig -A -o yaml 
apiVersion: v1
items:
- apiVersion: vdo.vmware.com/v1alpha1
  kind: VsphereCloudConfig
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"vdo.vmware.com/v1alpha1","kind":"VsphereCloudConfig","metadata":{"annotations":{},"name":"vspherecloudconfig-sample","namespace":"vmware-system-vdo"},"spec":{"credentials":"10.184.98.120-creds","datacenters":[],"insecure":true,"vcIp":"10.184.98.120"}}
    creationTimestamp: "2021-10-02T11:01:23Z"
    generation: 1
    name: vspherecloudconfig-sample
    namespace: vmware-system-vdo
    resourceVersion: "2453"
    uid: 1d31be6f-cb39-4077-bbea-4c3ea5c544c3
  spec:
    credentials: 10.184.98.120-creds
    datacenters: []
    insecure: true
    vcIp: 10.184.98.120
  status:
    config: verified
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""

```

```
 kubectl get vdoconfig -A -o yaml
apiVersion: v1
items:
- apiVersion: vdo.vmware.com/v1alpha1
  kind: VDOConfig
  metadata:
    annotations:
      kubectl.kubernetes.io/last-applied-configuration: |
        {"apiVersion":"vdo.vmware.com/v1alpha1","kind":"VDOConfig","metadata":{"annotations":{},"name":"vdoconfig-sample","namespace":"vmware-system-vdo"},"spec":{"cloudProvider":{"vsphereCloudConfigs":["vspherecloudconfig-sample"]},"storageProvider":{"vsphereCloudConfig":"vspherecloudconfig-sample"}}}
    creationTimestamp: "2021-10-02T11:01:17Z"
    generation: 1
    name: vdoconfig-sample
    namespace: vmware-system-vdo
    resourceVersion: "3575"
    uid: 37640c99-56a2-41d4-92f2-46f1f5809584
  spec:
    cloudProvider:
      vsphereCloudConfigs:
      - vspherecloudconfig-sample
    storageProvider:
      vsphereCloudConfig: vspherecloudconfig-sample
  status:
    cpi:
      'nodeStatus ':
        kind-control-plane: ready
      phase: Configured
    csi:
      phase: Configuring
kind: List
metadata:
  resourceVersion: ""
  selfLink: ""

```