### PR TITLE
fixes issue in controller

### DIFF
--- a/controllers/vdoconfig_controller.go
+++ b/controllers/vdoconfig_controller.go
@@ -461,7 +461,8 @@ func (r *VDOConfigReconciler) reconcileCSIConfiguration(vdoctx vdocontext.VDOCon
 		return ctrl.Result{}, err
 	}
 
-	if vdoConfig.Status.CSIStatus.Phase == vdov1alpha1.Deploying {
+	if vdoConfig.Status.CSIStatus.Phase == vdov1alpha1.Deploying ||
+		vdoConfig.Status.CSIStatus.Phase == vdov1alpha1.Configuring {
 		err = r.updateCSIPhase(vdoctx, vdoConfig, vdov1alpha1.Deployed, "")
 		if err != nil {
 			return ctrl.Result{}, err


### PR DESCRIPTION
**What type of PR is this?**
 /kind bug fix

**What this PR does / why we need it**:
This fixes an issue in the controller where CSI is stuc at configuring phase. when the reconcile is called again and CSI is already deployed, at this point in time CSI is in `configuring` state. As CSI is already deployed we skip updating the deployed phase.

**Test Report Added?**:
/kind TESTED

**Test Report**:
Tested on kind cluster and vanilla k8s cluster
