### PR TITLE
fixing the vdoctl version when VDO is not configured

### DIFF
--- a/vdoctl/cmd/deploy.go
+++ b/vdoctl/cmd/deploy.go
@@ -75,5 +75,6 @@ Currently the command supports deployment on vanilla k8s cluster`,
 
 func init() {
 	deployCmd.Flags().StringVar(&specfile, "spec", "", "url to vdo deployment spec file")
+	_ = deployCmd.MarkFlagRequired("spec")
 	rootCmd.AddCommand(deployCmd)
 }

--- a/vdoctl/cmd/drivers.go
+++ b/vdoctl/cmd/drivers.go
@@ -69,7 +69,7 @@ var driversCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 
-		err := IsVDODeployed(ctx)
+		err, _ := IsVDODeployed(ctx)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				fmt.Println(VDO_NOT_DEPLOYED)

--- a/vdoctl/cmd/status.go
+++ b/vdoctl/cmd/status.go
@@ -39,7 +39,7 @@ var statusCmd = &cobra.Command{
 
 		ctx := context.Background()
 
-		err := IsVDODeployed(ctx)
+		err, _ := IsVDODeployed(ctx)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				fmt.Println(VDO_NOT_DEPLOYED)
@@ -87,11 +87,11 @@ var statusCmd = &cobra.Command{
 	},
 }
 
-func IsVDODeployed(ctx context.Context) error {
+func IsVDODeployed(ctx context.Context) (error, *v12.Deployment) {
 	deployment := &v12.Deployment{}
 	ns := types.NamespacedName{Namespace: VdoNamespace, Name: VdoDeploymentName}
 	err := K8sClient.Get(ctx, ns, deployment)
-	return err
+	return err, deployment
 }
 
 // Fetch VC IP of given VsphereCloudConfig

--- a/vdoctl/cmd/version.go
+++ b/vdoctl/cmd/version.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"context"
-	"encoding/json"
 	"fmt"
 	"github.com/spf13/cobra"
 	vdov1alpha1 "github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/api/v1alpha1"
@@ -28,6 +27,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -38,6 +38,14 @@ const (
 	VdoDeploymentName = "vdo-controller-manager"
 )
 
+var (
+	vdoVersion     = "Not Configured"
+	vsphereVersion []string
+	k8sVersion     = "Not Configured"
+	csiVersion     = "Not Configured"
+	cpiVersion     = "Not Configured"
+)
+
 // versionCmd represents the version command
 var versionCmd = &cobra.Command{
 	Use:   "version",
@@ -45,30 +53,32 @@ var versionCmd = &cobra.Command{
 	Long:  "This command helps to get the version of the configurations created by VDO.\nIt includes brief detail about the version of CloudProvider and StorageProvider along with VC and Kubernetes details",
 	Run: func(cmd *cobra.Command, args []string) {
 
-		var vdoConfigList vdov1alpha1.VDOConfigList
-
 		ctx := vdocontext.VDOContext{
 			Context: context.Background(),
 			Logger:  ctrllog.Log.WithName("vdoctl:version"),
 		}
 
-		err := IsVDODeployed(ctx)
+		k8sVersion = getK8sVersion()
+
+		err, vdoDeployment := IsVDODeployed(ctx)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
-				fmt.Println(VDO_NOT_DEPLOYED)
+				showVersionInfo()
 				return
 			} else {
 				cobra.CheckErr(err)
 			}
 		}
+		vdoVersion, _ = getVdoVersion(vdoDeployment)
 
+		var vdoConfigList vdov1alpha1.VDOConfigList
 		err = K8sClient.List(ctx, &vdoConfigList)
 		if err != nil {
 			cobra.CheckErr(err)
 		}
 
 		if len(vdoConfigList.Items) <= 0 {
-			fmt.Println("VDO is not configured. you can use `vdoctl configure drivers` to configure VDO")
+			showVersionInfo()
 			return
 		}
 
@@ -92,48 +102,6 @@ var versionCmd = &cobra.Command{
 			},
 		}
 
-		deploymentReq := reconcile.Request{
-			NamespacedName: types.NamespacedName{
-				Name:      VdoDeploymentName,
-				Namespace: VdoNamespace,
-			},
-		}
-
-		// Fetch VDO deployment object
-		deployment := &v12.Deployment{}
-		err = K8sClient.Get(ctx, deploymentReq.NamespacedName, deployment)
-		if err != nil {
-			cobra.CheckErr(err)
-		}
-
-		var deploymentData string
-
-		for _, v := range deployment.Annotations {
-			if strings.Contains(v, "image") {
-				deploymentData = v
-				break
-			}
-		}
-
-		var deploymentMap map[string]interface{}
-		if err = json.Unmarshal([]byte(deploymentData), &deploymentMap); err != nil {
-			cobra.CheckErr(err)
-		}
-
-		containerInfo := deploymentMap["spec"].(map[string]interface{})["template"].(map[string]interface{})["spec"].(map[string]interface{})["containers"].([]interface{})
-
-		var imageName interface{}
-		for i, container := range containerInfo {
-			if container.(map[string]interface{})["name"] == "manager" {
-				imageName = containerInfo[i].(map[string]interface{})["image"]
-				break
-			}
-		}
-
-		vdoVersion := strings.Split(fmt.Sprint(imageName), ":")
-
-		fmt.Printf("VDO Version        : %s", vdoVersion[len(vdoVersion)-1])
-
 		configMap := &v1.ConfigMap{}
 		err = K8sClient.Get(ctx, req.NamespacedName, configMap)
 		if err != nil {
@@ -145,26 +113,51 @@ var versionCmd = &cobra.Command{
 			cobra.CheckErr(err)
 		}
 
-		vSphereVersion, _ := r.FetchVsphereVersions(ctx, req, &vdoConfig)
-		fmt.Printf("\nvSphere Versions   : %s", vSphereVersion)
+		vsphereVersion, _ = r.FetchVsphereVersions(ctx, req, &vdoConfig)
 
-		k8sVersion, _ := r.Fetchk8sVersions(ctx)
-		fmt.Printf("\nkubernetes Version : %s", k8sVersion)
-
-		err = r.FetchCsiDeploymentYamls(ctx, matrixConfig, vSphereVersion, k8sVersion)
+		err = r.FetchCsiDeploymentYamls(ctx, matrixConfig, vsphereVersion, k8sVersion)
 		if err != nil {
 			cobra.CheckErr(err)
 		}
-		fmt.Printf("\nCSI Version        : %s", r.CurrentCSIDeployedVersion)
+		csiVersion = r.CurrentCSIDeployedVersion
 
 		if len(vdoConfig.Spec.CloudProvider.VsphereCloudConfigs) > 0 {
-			err = r.FetchCpiDeploymentYamls(ctx, matrixConfig, vSphereVersion, k8sVersion)
+			err = r.FetchCpiDeploymentYamls(ctx, matrixConfig, vsphereVersion, k8sVersion)
 			if err != nil {
 				cobra.CheckErr(err)
 			}
-			fmt.Printf("\nCPI Version        : %s\n", r.CurrentCPIDeployedVersion)
+			cpiVersion = r.CurrentCPIDeployedVersion
 		}
+		showVersionInfo()
 	},
+}
+
+func getK8sVersion() string {
+	discoveryClient, _ := discovery.NewDiscoveryClientForConfig(ClientConfig)
+	k8sServerVersion, _ := discoveryClient.ServerVersion()
+	return k8sServerVersion.Major + "." + k8sServerVersion.Minor
+}
+
+func getVdoVersion(vdoDeployment *v12.Deployment) (string, error) {
+	containersList := vdoDeployment.Spec.Template.Spec.Containers
+	var containerImage string
+	for _, container := range containersList {
+		if strings.Contains(container.Name, "manager") {
+			containerImage = container.Image
+			break
+		}
+	}
+
+	vdoVersionInfo := strings.Split(fmt.Sprint(containerImage), ":")
+	return vdoVersionInfo[len(vdoVersionInfo)-1], nil
+}
+
+func showVersionInfo() {
+	fmt.Printf("kubernetes Version : %s", k8sVersion)
+	fmt.Printf("\nVDO Version        : %s", vdoVersion)
+	fmt.Printf("\nvSphere Versions   : %s", vsphereVersion)
+	fmt.Printf("\nCSI Version        : %s", csiVersion)
+	fmt.Printf("\nCPI Version        : %s\n", cpiVersion)
 }
 
 func init() {


### PR DESCRIPTION
**What type of PR is this?**
/kind bug fix


**What this PR does / why we need it**:
- fixing the vdoctl version when VDO is not configured and also when the CSI/CPI is not configured
- making the `spec` flag required when using the `vdoctl deploy`


**Which issue(s) this PR fixes**:
Fixes #56 

**Test Report Added?**:
/kind TESTED

**Test Report**:
Tried end to end workflow using the `vdoctl` on a local kind cluster by deploying VDO and configuring CSI and CPI using vdoctl
```
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl version
kubernetes Version : 1.21
VDO Version        : Not Configured
vSphere Versions   : []
CSI Version        : Not Configured
CPI Version        : Not Configured
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl status
VDO is not deployed. you can run `vdoctl deploy` command to deploy VDO
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl deploy
Error: required flag(s) "spec" not set
Usage:
  vdoctl deploy --spec <path to spec file> (can be http or file based url's) [flags]

Flags:
  -h, --help          help for deploy
      --spec string   url to vdo deployment spec file

Global Flags:
      --config string       config file (default is $HOME/.vdoctl.yaml)
      --kubeconfig string   points to the kubeconfig file of the target k8s cluster

Error: required flag(s) "spec" not set
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl deploy --spec file:///Users/kosarajud/Desktop/wcp/vsphere-kubernetes-drivers-operator/artifacts/vanilla/vdo-spec.yaml 
Tip: now that you have deployed VDO, you might want to try 'vdoctl configure drivers' to configure vsphere drivers
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl configure compatibility-matrix
✔ Web URL
Web URL https://raw.githubusercontent.com/asifdxtreme/Docs/master/compat/upgrade-matrix.yaml
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl status
VDO is not configured. you can use `vdoctl configure drivers` to configure VDO
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl version
kubernetes Version : 1.21
VDO Version        : c39004f
vSphere Versions   : []
CSI Version        : Not Configured
CPI Version        : Not Configured
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl configure drivers
Do you want to configure CloudProvider? (Y/N) Y
Please provide the vcenter IP for configuring CloudProvider 
VC IP 10.161.81.243
Do you want to establish a secure connection? (Y/N) N
Please provide the credentials for configuring CloudProvider
Username administrator@vsphere.local
Password ********
Datacenter(s) WCP_DC
Do you want to configure another vcenter for CloudProvider? (Y/N) N
Do you want to configure zones/regions for CloudProvider? (Y/N) N
You have now completed configuration of CloudProvider. We will now proceed to configure StorageProvider.
Please provide the credentials for configuring StorageProvider
Username administrator@vsphere.local
Password ********█
Datacenter(s) WCP_DC
Do you wish to configure File Volumes? (Y/N) N
Thanks for configuring VDO. The drivers will now be installed.
You can check the status for drivers using `vdoctl status`
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl version
kubernetes Version : 1.21
VDO Version        : c39004f
vSphere Versions   : [7.0.3]
CSI Version        : 2.2.1
CPI Version        : 1.20.0
```

**Special notes for your reviewer**:
When VDO itself is not configured, `vdoctl version` output just shows the Kubernetes version as vdoctl is able to detect the Kubernetes version