### PR TITLE
Fixing vdoctl version when VDO is running on the cluster without CSI/CPI configured

### DIFF
--- a/vdoctl/cmd/deploy.go
+++ b/vdoctl/cmd/deploy.go
@@ -75,5 +75,6 @@ Currently the command supports deployment on vanilla k8s cluster`,
 
 func init() {
 	deployCmd.Flags().StringVar(&specfile, "spec", "", "url to vdo deployment spec file")
+	_ = deployCmd.MarkFlagRequired("spec")
 	rootCmd.AddCommand(deployCmd)
 }

--- a/vdoctl/cmd/drivers.go
+++ b/vdoctl/cmd/drivers.go
@@ -69,7 +69,7 @@ var driversCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		ctx := context.Background()
 
-		err := IsVDODeployed(ctx)
+		err, _ := IsVDODeployed(ctx)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				fmt.Println(VDO_NOT_DEPLOYED)

--- a/vdoctl/cmd/status.go
+++ b/vdoctl/cmd/status.go
@@ -39,7 +39,7 @@ var statusCmd = &cobra.Command{
 
 		ctx := context.Background()
 
-		err := IsVDODeployed(ctx)
+		err, _ := IsVDODeployed(ctx)
 		if err != nil {
 			if apierrors.IsNotFound(err) {
 				fmt.Println(VDO_NOT_DEPLOYED)
@@ -87,11 +87,14 @@ var statusCmd = &cobra.Command{
 	},
 }
 
-func IsVDODeployed(ctx context.Context) error {
+func IsVDODeployed(ctx context.Context) (error, *v12.Deployment) {
 	deployment := &v12.Deployment{}
 	ns := types.NamespacedName{Namespace: VdoNamespace, Name: VdoDeploymentName}
 	err := K8sClient.Get(ctx, ns, deployment)
-	return err
+	if deployment.Status.Replicas != deployment.Status.AvailableReplicas {
+		return fmt.Errorf("not enough replicas of VDO"), nil
+	}
+	return err, deployment
 }
 
 // Fetch VC IP of given VsphereCloudConfig


### PR DESCRIPTION
**What type of PR is this?**
/kind bug fix

**What this PR does / why we need it:**
- fixing the `vdoctl version` when VDO is not configured and also when the CSI/CPI is not configured
- making the `spec` flag required when using the vdoctl deploy

**Which issue(s) this PR fixes:**
Fixes #56

**Test Report Added?:**
/kind TESTED

**Test Report:**
Tried end to end workflow using the `vdoctl` on a local kind cluster by deploying VDO and configuring CSI and CPI using vdoctl

```
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl version
kubernetes Version : 1.21
VDO Version        : Not Configured
vSphere Versions   : []
CSI Version        : Not Configured
CPI Version        : Not Configured
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl deploy
Error: required flag(s) "spec" not set
Usage:
  vdoctl deploy --spec <path to spec file> (can be http or file based url's) [flags]

Flags:
  -h, --help          help for deploy
      --spec string   url to vdo deployment spec file

Global Flags:
      --config string       config file (default is $HOME/.vdoctl.yaml)
      --kubeconfig string   points to the kubeconfig file of the target k8s cluster

Error: required flag(s) "spec" not set
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl status
VDO is not deployed. you can run `vdoctl deploy` command to deploy VDO
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl deploy --spec file:///Users/kosarajud/Desktop/wcp/vsphere-kubernetes-drivers-operator/artifacts/vanilla/vdo-spec.yaml 
Tip: now that you have deployed VDO, you might want to try 'vdoctl configure drivers' to configure vsphere drivers
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ k get rs -A
NAMESPACE            NAME                                DESIRED   CURRENT   READY   AGE
kube-system          coredns-558bd4d5db                  2         2         2       2d4h
kube-system          vsphere-csi-controller-55f949b89    1         1         1       2d
local-path-storage   local-path-provisioner-547f784dff   1         1         1       2d4h
vmware-system-vdo    vdo-controller-manager-54c77c749c   1         1         0       15s
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl version
Error: not enough replicas of VDO
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl status 
Error: not enough replicas of VDO
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl configure compatibility-matrix
✔ Web URL
Web URL https://raw.githubusercontent.com/asifdxtreme/Docs/master/compat/upgrade-matrix.yaml
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ k get rs -A
NAMESPACE            NAME                                DESIRED   CURRENT   READY   AGE
kube-system          coredns-558bd4d5db                  2         2         2       2d4h
kube-system          vsphere-csi-controller-55f949b89    1         1         1       2d
local-path-storage   local-path-provisioner-547f784dff   1         1         1       2d4h
vmware-system-vdo    vdo-controller-manager-54c77c749c   1         1         1       71s
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl status
VDO is not configured. you can use `vdoctl configure drivers` to configure VDO
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl version
kubernetes Version : 1.21
VDO Version        : v0.1.0-beta
vSphere Versions   : []
CSI Version        : Not Configured
CPI Version        : Not Configured
# After configuring
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl version
kubernetes Version : 1.21
VDO Version        : v0.1.0-beta
vSphere Versions   : [7.0.3]
CSI Version        : 2.2.1
CPI Version        : 1.20.0
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ vdoctl status 
CloudProvider   : Configured
         vCenter : 
                10.161.81.243  (Credentials Verified)
         Nodes : 
                 kind-control-plane : ready 
StorageProvider : Deployed
         vCenter : 
                10.161.81.243  (Credentials Verified)
```

**Special notes for your reviewer:**
When VDO itself is not configured, vdoctl version output just shows the Kubernetes version as vdoctl is able to detect the Kubernetes version