### PR TITLE
Docker file changes for Redhat Certification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,12 +20,12 @@ RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -ldflags '-extldflags "-st
 FROM registry.access.redhat.com/ubi8/ubi-minimal:latest
 
 LABEL name="vsphere-kubernetes-drivers-operators"
-LABEL maintainer="vdo-dev@vmware.com"
+LABEL maintainer="vdo@vmware.com"
 LABEL vendor="VMware"
 LABEL version="0.0.1"
 LABEL release="1"
 LABEL summary="Kubernetes Operator to manage vSphere Kubernetes drivers."
-LABEL description="vSphere Kubernetes Drivers Operator manages vSphere CSI/CPI drivers lifecycle on Kubernetes."
+LABEL description="vSphere Kubernetes Drivers Operator manages lifecycle of vSphere CSI/CPI drivers on Kubernetes."
 
 WORKDIR /
 COPY --from=builder /workspace/manager .


### PR DESCRIPTION
Docker file changes for Redhat Certification

**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
Adding new Labels to Docker image as per the Redhat Certification Process (Refer [this](https://redhat-connect.gitbook.io/partner-guide-for-red-hat-openshift-and-container/program-on-boarding/technical-prerequisites#example-dockerfile-for-container-application))

**Which issue(s) this PR fixes**:
Fixes #69 

**Test Report Added?**:
/kind TESTED

**Test Report**:
After building the docker images tested the labels
```
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ docker inspect -f='{{.Config.Labels.name}}' 10d85b4bfa4f
vsphere-kubernetes-drivers-operators
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ docker inspect -f='{{.Config.Labels.maintainer}}' 10d85b4bfa4f
vdo-dev@vmware.com
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ docker inspect -f='{{.Config.Labels.vendor}}' 10d85b4bfa4f
VMware
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ docker inspect -f='{{.Config.Labels.version}}' 10d85b4bfa4f
0.0.1
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ docker inspect -f='{{.Config.Labels.release}}' 10d85b4bfa4f
1
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ docker inspect -f='{{.Config.Labels.summary}}' 10d85b4bfa4f
Kubernetes Operator to manage vSphere Kubernetes drivers.
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ docker inspect -f='{{.Config.Labels.description}}' 10d85b4bfa4f
vSphere Kubernetes Drivers Operator manages vSphere CSI/CPI drivers lifecycle on Kubernetes.
```