### PR TITLE
Fixing the vdoctl version

### DIFF
--- a/vdoctl/cmd/version.go
+++ b/vdoctl/cmd/version.go
@@ -17,12 +17,14 @@ package cmd
 
 import (
 	"context"
+	"encoding/json"
 	"fmt"
 	"github.com/spf13/cobra"
 	vdov1alpha1 "github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/api/v1alpha1"
 	"github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/controllers"
 	dynclient "github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/client"
 	vdocontext "github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/context"
+	"github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/pkg/models"
 	v12 "k8s.io/api/apps/v1"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -108,7 +110,13 @@ var versionCmd = &cobra.Command{
 			cobra.CheckErr(err)
 		}
 
-		matrixConfig, err := dynclient.ParseMatrixYaml(configMap.Data["versionConfigURL"])
+		var matrixConfig models.CompatMatrix
+		if matrixConfigUrl, ok := configMap.Data["versionConfigURL"]; ok {
+			matrixConfig, err = dynclient.ParseMatrixYaml(matrixConfigUrl)
+		} else {
+			err = json.Unmarshal([]byte(configMap.Data["versionConfigContent"]), &matrixConfig)
+		}
+
 		if err != nil {
 			cobra.CheckErr(err)
 		}


### PR DESCRIPTION
Fixing the vdoctl version when the compatibility matrix is provided using a local file

**What type of PR is this?**
> /kind bug fix

**What this PR does / why we need it**:
vdoctl version will not work properly is the compatibility matrix is provided 

**Which issue(s) this PR fixes**:
Fixes #84 

**Test Report Added?**:
/kind TESTED


**Test Report**:
When the compatibility matrix is from a URL
```
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ ./bin/vdoctl version
kubernetes Version : 1.21
VDO Version        : 9d4bc2a
vSphere Versions   : [7.0.3]
CSI Version        : 2.2.1
CPI Version        : 1.20.0
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ kubectl describe cm compat-matrix-config -n vmware-system-vdo
Name:         compat-matrix-config
Namespace:    vmware-system-vdo
Labels:       <none>
Annotations:  <none>

Data
====
auto-upgrade:
----
disabled
versionConfigURL:
----
https://raw.githubusercontent.com/asifdxtreme/Docs/master/compat/upgrade-matrix.yaml
Events:  <none>
```

When the compatibility matrix is from a local file
```
bash-5.1$ kubectl describe cm compat-matrix-config -n vmware-system-vdo
Name:         compat-matrix-config
Namespace:    vmware-system-vdo
Labels:       <none>
Annotations:  <none>

Data
====
auto-upgrade:
----
disabled
versionConfigContent:
----
{
    "CSI" : {
             "2.2.1" : {
                    "vSphere" : { "min" : "6.7.1", "max": "7.0.4"},
                    "k8s" : {"min": "1.18", "max": "1.22"},
                    "isCPIRequired" : false,
                    "deploymentPath": [
                    "https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/v2.2.1/manifests/v2.2.1/rbac/vsphere-csi-controller-rbac.yaml",
                    "https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/v2.2.1/manifests/v2.2.1/rbac/vsphere-csi-node-rbac.yaml",
                    "https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/v2.2.1/manifests/v2.2.1/deploy/vsphere-csi-controller-deployment.yaml",
                    "https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/v2.2.1/manifests/v2.2.1/deploy/vsphere-csi-node-ds.yaml"]
                    },
            "2.2.0" : {
                    "vSphere" : { "min" : "6.7.1", "max": "7.0.4"},
                    "k8s" : {"min": "1.18", "max": "1.22"},
                    "isCPIRequired" : false,
                    "deploymentPath": [
                    "https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/v2.2.0/manifests/v2.2.0/rbac/vsphere-csi-controller-rbac.yaml",
                    "https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/v2.2.0/manifests/v2.2.0/rbac/vsphere-csi-node-rbac.yaml",
                    "https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/v2.2.0/manifests/v2.2.0/deploy/vsphere-csi-controller-deployment.yaml",
                    "https://raw.githubusercontent.com/kubernetes-sigs/vsphere-csi-driver/v2.2.0/manifests/v2.2.0/deploy/vsphere-csi-node-ds.yaml"]
                    }
        },
    "CPI" : {
            "1.20.0" : {
                    "vSphere" : { "min" : "6.7.1", "max": "7.0.4"},
                    "k8s" : {"skewVersion": "1.22"},
                    "deploymentPath": [
                    "https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/v1.20.0/manifests/controller-manager/cloud-controller-manager-roles.yaml",
                    "https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/v1.20.0/manifests/controller-manager/cloud-controller-manager-role-bindings.yaml",
                    "https://raw.githubusercontent.com/kubernetes/cloud-provider-vsphere/v1.20.0/manifests/controller-manager/vsphere-cloud-controller-manager-ds.yaml"]
                    }
        }
             
}

Events:  <none>
bash-5.1$ vdoctl version
kubernetes Version : 1.22
VDO Version        : c39004f
vSphere Versions   : [7.0.3]
CSI Version        : 2.2.1
CPI Version        : 1.20.0
```
