### PR TITLE
Making linter timeout parameter configurable based on the Env variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,11 @@ else
 GOLANGCI_LINT_TIMEOUT = 2m
 endif
 
+# if kind node image is passed use that instead of the default one used by kind
+ifneq ($(origin KIND_NODE_IMAGE), undefined)
+LOCAL_KIND_NODE_IMAGE = --image ${KIND_NODE_IMAGE}
+endif
+
 # DEFAULT_CHANNEL defines the default channel used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g DEFAULT_CHANNEL = "stable")
 # To re-generate a bundle for any other default channel without changing the default setup, you can:
@@ -212,7 +217,7 @@ kind-cluster: kind ## Create a kind cluster if one does not exist
 		echo "Using existing kind cluster ${KIND_CLUSTER_NAME}" ; \
 	else \
 		echo "Creating cluster with kind..." ; \
-		$(KIND) create cluster --name ${KIND_CLUSTER_NAME} -v 3  ; \
+		$(KIND) create cluster --name ${KIND_CLUSTER_NAME} ${LOCAL_KIND_NODE_IMAGE} -v 3  ; \
 	fi
 
 .PHONY: bundle

--- a/Makefile
+++ b/Makefile
@@ -26,6 +26,14 @@ CRC					?= crc
 SPEC_FILE			?= vdo-spec.yaml
 CRC					?= crc
 
+# Configure the golangci-lint timeout if an environment variable exists
+ifneq ($(origin LINT_TIMEOUT), undefined)
+GOLANGCI_LINT_TIMEOUT = ${LINT_TIMEOUT}
+else
+# Set the default timeout to 2m
+GOLANGCI_LINT_TIMEOUT = 2m
+endif
+
 # DEFAULT_CHANNEL defines the default channel used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g DEFAULT_CHANNEL = "stable")
 # To re-generate a bundle for any other default channel without changing the default setup, you can:
@@ -298,7 +306,7 @@ lint-go: golangci_lint ## Lint codebase
 	$(GOLANGCI_LINT) run -v $(GOLANGCI_LINT_FLAGS)
 
 .PHONY: lint-go-full
-lint-go-full: GOLANGCI_LINT_FLAGS = --fast=false
+lint-go-full: GOLANGCI_LINT_FLAGS = --fast=false --timeout ${GOLANGCI_LINT_TIMEOUT}
 lint-go-full: lint-go ## Run slower linters to detect possible issues
 
 .PHONY: lint-markdown
@@ -316,7 +324,7 @@ fix: GOLANGCI_LINT_FLAGS = --fast=false --fix
 fix: lint-go ## Tries to fix errors reported by lint-go-full target
 
 GOLANGCI_LINT = $(shell pwd)/bin/golangci-lint
-golangci_lint: ## Download kustomize locally if necessary.
+golangci_lint: ## Download golangci-lint locally if necessary.
 	$(call go-get-tool,$(GOLANGCI_LINT),github.com/golangci/golangci-lint/cmd/golangci-lint)
 
 CONTROLLER_GEN = $(shell pwd)/bin/controller-gen


### PR DESCRIPTION
- Making linter timeout parameter configurable based on the Env variable and setting the default timeout to 2m
- Making kind node image configurable

**What type of PR is this?**
/kind enhancement

**What this PR does / why we need it**:
For CI/CD automation where linting takes more than 1m

**Which issue(s) this PR fixes**:
Fixes #88 

**Test Report Added?**:
/kind TESTED

**Test Report**:
- Default timeout
```
bash-5.1$ make build
/Users/kosarajud/Desktop/wcp/vsphere-kubernetes-drivers-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
/Applications/Xcode.app/Contents/Developer/usr/bin/make lint-go-full
/Users/kosarajud/Desktop/wcp/vsphere-kubernetes-drivers-operator/bin/golangci-lint run -v --fast=false --timeout 2m
INFO [config_reader] Config search paths: [./ /Users/kosarajud/Desktop/wcp/vsphere-kubernetes-drivers-operator /Users/kosarajud/Desktop/wcp /Users/kosarajud/Desktop /Users/kosarajud /Users /] 
```
- Passing the value in the make command
```
bash-5.1$ make build LINT_TIMEOUT=3m
/Users/kosarajud/Desktop/wcp/vsphere-kubernetes-drivers-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
/Applications/Xcode.app/Contents/Developer/usr/bin/make lint-go-full
/Users/kosarajud/Desktop/wcp/vsphere-kubernetes-drivers-operator/bin/golangci-lint run -v --fast=false --timeout 3m
```
- Setting the environment variable
```
bash-5.1$ export LINT_TIMEOUT=3m
bash-5.1$ make build
/Users/kosarajud/Desktop/wcp/vsphere-kubernetes-drivers-operator/bin/controller-gen object:headerFile="hack/boilerplate.go.txt" paths="./..."
go fmt ./...
go vet ./...
/Applications/Xcode.app/Contents/Developer/usr/bin/make lint-go-full
/Users/kosarajud/Desktop/wcp/vsphere-kubernetes-drivers-operator/bin/golangci-lint run -v --fast=false --timeout 3m
```
- Ran `make build-vdoctl-mac`
- Ran `make test`
- Kind node image configurable
```
kosarajud-a02:vsphere-kubernetes-drivers-operator kosarajud$ make deploy KIND_NODE_IMAGE=harbor-repo.vmware.com/dockerhub-proxy-cache/kindest/node:v1.21.1
/Users/kosarajud/Desktop/wcp/vsphere-kubernetes-drivers-operator/bin/controller-gen "crd:trivialVersions=true,preserveUnknownFields=false" output:rbac:dir=./config/rbac rbac:roleName=manager-role webhook paths="./..." output:crd:artifacts:config=config/crd/bases
cd config/manager && /Users/kosarajud/Desktop/wcp/vsphere-kubernetes-drivers-operator/bin/kustomize edit set image controller=vmware.com/vdo:08bcbd4
/Users/kosarajud/Desktop/wcp/vsphere-kubernetes-drivers-operator/bin/kustomize build config/default > artifacts/vanilla/vdo-spec.yaml
No kind clusters found.
Creating cluster with kind...
Creating cluster "kind" ...
DEBUG: docker/images.go:58] Image: harbor-repo.vmware.com/dockerhub-proxy-cache/kindest/node:v1.21.1 present locally
 ✓ Ensuring node image (harbor-repo.vmware.com/dockerhub-proxy-cache/kindest/node:v1.21.1) 🖼 
```

**Special notes for your reviewer**:
During my automation linting is taking around 1m 30s so the default was set to 2m