### PR TITLE
Adding the go version in the Github pipeline

### DIFF
--- a/.github/workflows/BuildAndDeploy.yml
+++ b/.github/workflows/BuildAndDeploy.yml
@@ -22,7 +22,6 @@ jobs:
         uses: actions/setup-go@v2.1.4
         with:
           go-version: '1.16'
-        run: go version
 
       - name: Build and Deploy
         run: make deploy

--- a/.github/workflows/BuildAndDeploy.yml
+++ b/.github/workflows/BuildAndDeploy.yml
@@ -20,6 +20,9 @@ jobs:
 
       - name: Setup Go environment
         uses: actions/setup-go@v2.1.4
+        with:
+          go-version: '1.16'
+        run: go version
 
       - name: Build and Deploy
         run: make deploy


### PR DESCRIPTION
Adding the go version in the Github pipeline

**What type of PR is this?**
/kind bug fix


**What this PR does / why we need it**:
the pre-commit pipeline is failing without this fix

**Which issue(s) this PR fixes**:
Fixes #91 

**Test Report Added?**:
/kind TESTED

**Test Report**:
- Tested the change on the forked repo
   Build [link](https://github.com/DimpleRajaVamsi/vsphere-kubernetes-drivers-operator/actions/runs/1442780973)
- go version in the above run
![Screenshot 2021-11-10 at 11 21 51 AM](https://user-images.githubusercontent.com/10498902/141058988-3cb87706-c8dc-4532-9d2b-5e86530bb8ff.png)