### PR TITLE
Fix vdoctl to avoid KUBECONFIG check on invocation of help command

### DIFF
--- a/vdoctl/cmd/root.go
+++ b/vdoctl/cmd/root.go
@@ -103,18 +103,20 @@ func initConfig() {
 	}
 
 	// Ignore the config check and client creation if help command is invoked
-	if os.Args[1] != "help" {
+	if os.Args[1] == "help" {
+		return
+	}
+
+	if len(kubeconfig) <= 0 {
+		kubeconfig = os.Getenv("KUBECONFIG")
 		if len(kubeconfig) <= 0 {
-			kubeconfig = os.Getenv("KUBECONFIG")
-			if len(kubeconfig) <= 0 {
-				cobra.CheckErr(errors.New("could not detect a target kubernetes cluster. " +
-					"Either use --kubeconfig flag or set KUBECONFIG environment variable"))
-			}
+			cobra.CheckErr(errors.New("could not detect a target kubernetes cluster. " +
+				"Either use --kubeconfig flag or set KUBECONFIG environment variable"))
 		}
-		err := generateK8sClient(kubeconfig)
-		if err != nil {
-			cobra.CheckErr(err)
-		}
+	}
+	err := generateK8sClient(kubeconfig)
+	if err != nil {
+		cobra.CheckErr(err)
 	}
 }
 

--- a/vdoctl/cmd/root.go
+++ b/vdoctl/cmd/root.go
@@ -102,19 +102,20 @@ func initConfig() {
 		fmt.Fprintln(os.Stderr, "Using config file:", viper.ConfigFileUsed())
 	}
 
-	if len(kubeconfig) <= 0 {
-		kubeconfig = os.Getenv("KUBECONFIG")
+	// Ignore the config check and client creation if help command is invoked
+	if os.Args[1] != "help" {
 		if len(kubeconfig) <= 0 {
-			cobra.CheckErr(errors.New("could not detect a target kubernetes cluster. " +
-				"Either use --kubeconfig flag or set KUBECONFIG environment variable"))
+			kubeconfig = os.Getenv("KUBECONFIG")
+			if len(kubeconfig) <= 0 {
+				cobra.CheckErr(errors.New("could not detect a target kubernetes cluster. " +
+					"Either use --kubeconfig flag or set KUBECONFIG environment variable"))
+			}
+		}
+		err := generateK8sClient(kubeconfig)
+		if err != nil {
+			cobra.CheckErr(err)
 		}
 	}
-
-	err := generateK8sClient(kubeconfig)
-	if err != nil {
-		cobra.CheckErr(err)
-	}
-
 }
 
 func generateK8sClient(kubeconfig string) error {

--- a/vdoctl/cmd/root.go
+++ b/vdoctl/cmd/root.go
@@ -114,10 +114,12 @@ func initConfig() {
 				"Either use --kubeconfig flag or set KUBECONFIG environment variable"))
 		}
 	}
+
 	err := generateK8sClient(kubeconfig)
 	if err != nil {
 		cobra.CheckErr(err)
 	}
+
 }
 
 func generateK8sClient(kubeconfig string) error {


### PR DESCRIPTION
**What type of PR is this?**
kind enhancement

**What this PR does / why we need it**:

vdoctl is excepting for KUBECONFIG env variable to be set before user enter any CLI commands.
This PR will allow user to invoke the help command without any pre-requisites ( KUBECONFIG env variable )

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #70 

**Test Report Added?**:
kind TESTED

**Test Report**:

```
ridaz@ridaz-a01 vsphere-kubernetes-drivers-operator % unset KUBECONFIG
ridaz@ridaz-a01 vsphere-kubernetes-drivers-operator % bin/vdoctl help
vdoctl is a command line interface for vSphere Kubernetes Drivers Operator.
vdoctl provides the user with basic set of commands required to install and configure VDO.

Usage:
  vdoctl [command]

Available Commands:
  completion  generate the autocompletion script for the specified shell
  configure   command to configure VDO
  delete      Delete vSphere Kubernetes Driver Operator
  deploy      Deploy vSphere Kubernetes Driver Operator
  help        Help about any command
  status      command to get VDO status
  update      Update the VDO Resources
  version     command to get VDO version

Flags:
      --config string       config file (default is $HOME/.vdoctl.yaml)
  -h, --help                help for vdoctl
      --kubeconfig string   points to the kubeconfig file of the target k8s cluster

Use "vdoctl [command] --help" for more information about a command.
```
<img width="835" alt="vdoctl help" src="https://user-images.githubusercontent.com/88429350/141849723-66c85aec-a91a-440d-9b52-0ae525f58054.png">


```
ridaz@ridaz-a01 vsphere-kubernetes-drivers-operator % bin/vdoctl help status
This command helps to get the status of the configurations created by VDO.
It includes brief detail about the status of CloudProvider and StorageProvider and Node details

Usage:
  vdoctl status [flags]

Flags:
  -h, --help   help for status

Global Flags:
      --config string       config file (default is $HOME/.vdoctl.yaml)
      --kubeconfig string   points to the kubeconfig file of the target k8s cluster



```