### PR TITLE
Fix usage of update command provided in the example field

### DIFF
--- a/vdoctl/cmd/update.go
+++ b/vdoctl/cmd/update.go
@@ -25,7 +25,7 @@ var updateCmd = &cobra.Command{
 	Aliases: []string{"u"},
 	Short:   "Update the VDO Resources",
 	Long:    `This command helps to update the VDO Resources which is created by VDO Controller.`,
-	Example: `vdoctl update matrix https://sample/sample.yaml
+	Example: `vdoctl update compatibility-matrix https://sample/sample.yaml
 `,
 }
 

--- a/vdoctl/cmd/update_matrix.go
+++ b/vdoctl/cmd/update_matrix.go
@@ -38,16 +38,16 @@ var matrixUpdateCmd = &cobra.Command{
 	Short:   "Command to update the Compatibility matrix of Drivers",
 	Long: `This command helps to update the Compatibility matrix of Drivers, 
 which in turns help to upgrade/downgrade the versions of CSI & CPI drivers.`,
-	Example: "vdoctl update matrix https://github.com/demo/demo.yaml\nvdoctl update matrix file://var/sample/sample.yaml",
+	Example: "vdoctl update compatibility-matrix https://github.com/demo/demo.yaml\nvdoctl update compatibility-matrix file://var/sample/sample.yaml",
 
 	Run: func(cmd *cobra.Command, args []string) {
 		cobra.MinimumNArgs(1)
-		updateMatrix(cmd, args)
+		updateMatrix(args)
 	},
 }
 
 // updateMatrix updates the ConfigMap containing the compatibility-matrix
-func updateMatrix(cmd *cobra.Command, args []string) {
+func updateMatrix(args []string) {
 
 	if len(args) < 1 {
 		cobra.CheckErr("At-least one argument should be provided")


### PR DESCRIPTION
**What type of PR is this?**
>/kind bug fix

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
Fixes #100 

**Test Report Added?**:
/kind TESTED

**Test Report**:

```
vdoctl help update
This command helps to update the VDO Resources which is created by VDO Controller.

Usage:
  vdoctl update [command]

Aliases:
  update, u

Examples:
vdoctl update compatibility-matrix https://sample/sample.yaml
```

```
vdoctl configure compatibility-matrix

kubectl describe configmaps -n vmware-system-vdo compat-matrix-config
versionConfigURL:
----
https://raw.githubusercontent.com/asifdxtreme/Docs/master/sample/matrix/matrix.yaml
```
```

vdoctl update compatibility-matrix https://raw.githubusercontent.com/ridaz/Sample-files/main/sample.yaml

kubectl describe configmaps -n vmware-system-vdo compat-matrix-config                                       
versionConfigURL:
----
https://raw.githubusercontent.com/ridaz/Sample-files/main/sample.yaml
```