### PR TITLE
Adds kubelet path replacement for DRIVER_REG_SOCK_PATH environment variable

### DIFF
--- a/controllers/vdoconfig_controller_test.go
+++ b/controllers/vdoconfig_controller_test.go
@@ -1588,6 +1588,19 @@ var _ = Describe("TestUpdatingKubeletPath", func() {
 									},
 								},
 							},
+							{
+								Name: string(csiNodeDriverRegName),
+								Env: []v12.EnvVar{
+									{
+										Name:  CSI_DRIVER_REG_PATH,
+										Value: "/var/lib/kubelet/plugins/csi.vsphere.vmware.com/csi.sock",
+									},
+									{
+										Name:  "ADDRESS",
+										Value: "/csi/csi.sock",
+									},
+								},
+							},
 						},
 					}},
 			},


### PR DESCRIPTION
Adds kubelet path replacement for DRIVER_REG_SOCK_PATH environment variable in node-driver-registrar container

**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespace from that line:
>
> /kind new feature

> /kind cleanup
> /kind revert change
> /kind design
> /kind documentation
> /kind enhancement

/kind bug fix

**What this PR does / why we need it**:
To enable CSI to work with custom kubelet path we need to modify the CSI daemonset with the desired kubelet path
**Which issue(s) this PR fixes**:

Fixes #125

**Test Report Added?**:
 /kind TESTED
> /kind NOT-TESTED