### PR TITLE
adding support and validation for providing FQDN

### DIFF
--- a/vdoctl/cmd/drivers.go
+++ b/vdoctl/cmd/drivers.go
@@ -106,7 +106,7 @@ var driversCmd = &cobra.Command{
 		labels := credentials{
 			username: "Username",
 			password: "Password",
-			vcIp:     "VC IP/FQDN",
+			vcIp:     "VC IP/ FQDN",
 			topology: v1alpha1.TopologyInfo{
 				Zone:   "Zones",
 				Region: "Regions",

--- a/vdoctl/cmd/drivers.go
+++ b/vdoctl/cmd/drivers.go
@@ -106,7 +106,7 @@ var driversCmd = &cobra.Command{
 		labels := credentials{
 			username: "Username",
 			password: "Password",
-			vcIp:     "VC IP",
+			vcIp:     "VC IP/FQDN",
 			topology: v1alpha1.TopologyInfo{
 				Zone:   "Zones",
 				Region: "Regions",
@@ -117,7 +117,7 @@ var driversCmd = &cobra.Command{
 		isCPIRequired := utils.PromptGetInput("Do you want to configure CloudProvider? (Y/N)", errors.New("invalid input"), utils.IsString)
 
 		if strings.EqualFold(isCPIRequired, "Y") {
-			fmt.Printf("Please provide the vcenter IP for configuring CloudProvider \n")
+			fmt.Printf("Please provide the vcenter IP/FQDN for configuring CloudProvider \n")
 
 		multivcloop:
 			for {
@@ -203,7 +203,7 @@ var driversCmd = &cobra.Command{
 			csi.insecure = cpi.insecure
 			csi.thumbprint = cpi.thumbprint
 		} else {
-			fmt.Printf("Please provide the vcenter IP for configuring StorageProvider \n")
+			fmt.Printf("Please provide the vcenter IP/FQDN for configuring StorageProvider \n")
 			fetchVCIP(&csi, labels)
 			if !csi.insecure {
 				fetchThumbprint(&csi, labels)
@@ -408,7 +408,7 @@ func createVDOConfig(cl client.Client, ctx context.Context, cpi credentials, csi
 }
 
 func fetchVCIP(cred *credentials, labels credentials) {
-	vcIp := utils.PromptGetInput(labels.vcIp, errors.New("unable to get the IP Address - Invalid input"), utils.IsIP)
+	vcIp := utils.PromptGetInput(labels.vcIp, errors.New("unable to get the IP Address/ FQDN - Invalid input"), utils.IsIPorFQDN)
 	cred.vcIp = vcIp
 
 	res := utils.PromptGetInput("Do you want to establish a secure connection? (Y/N)", errors.New("invalid input"), utils.IsString)

--- a/vdoctl/pkg/utils/promptutil.go
+++ b/vdoctl/pkg/utils/promptutil.go
@@ -7,16 +7,17 @@ import (
 	"net"
 	"net/url"
 	"os"
+	"regexp"
 	"strings"
 )
 
 type ValidationFlags string
 
 const (
-	IsPwd    ValidationFlags = "isPwd"
-	IsURL    ValidationFlags = "isURL"
-	IsIP     ValidationFlags = "isIP"
-	IsString ValidationFlags = "isString"
+	IsPwd      ValidationFlags = "isPwd"
+	IsURL      ValidationFlags = "isURL"
+	IsIPorFQDN ValidationFlags = "isIP"
+	IsString   ValidationFlags = "isString"
 )
 
 func CheckIfUrl(str string) bool {
@@ -39,6 +40,12 @@ func checkIPAddress(ip string) bool {
 	return net.ParseIP(ip) != nil
 }
 
+func checkIfFQDN(domain string) bool {
+	RegExp := regexp.MustCompile(`^([a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62}){1}(\.[a-zA-Z0-9_]{1}[a-zA-Z0-9_-]{0,62})+[\._]?[^\.]$`)
+	return RegExp.MatchString(domain)
+
+}
+
 func PromptGetInput(label string, err error, flag ValidationFlags) string {
 	validate := func(input string) error {
 		if len(input) <= 0 {
@@ -50,8 +57,8 @@ func PromptGetInput(label string, err error, flag ValidationFlags) string {
 
 		}
 
-		if flag == IsIP && !checkIPAddress(input) {
-			return errors.New("Please provide a valid IP address")
+		if flag == IsIPorFQDN && !(checkIPAddress(input) || checkIfFQDN(input)) {
+			return errors.New("Please provide a valid IP address/ FQDN")
 		}
 		return nil
 	}

--- a/vdoctl/pkg/utils/promptutil.go
+++ b/vdoctl/pkg/utils/promptutil.go
@@ -16,7 +16,7 @@ type ValidationFlags string
 const (
 	IsPwd      ValidationFlags = "isPwd"
 	IsURL      ValidationFlags = "isURL"
-	IsIPorFQDN ValidationFlags = "isIP"
+	IsIPorFQDN ValidationFlags = "isIPorFQDN"
 	IsString   ValidationFlags = "isString"
 )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. Please give clear description and fill all the needed fields in the PR template below
2. Provide all the test report and results for the PR. It is mandatory. Otherwise, 
   your PR may get rejected without any review/discussion
3. If the PR is incomplete/in progress, please add [WIP] at the beginning of the PR title.
4. Provide the link to the issue and other relevant files related to the PR
-->

**What type of PR is this?**
> /kind enhancement

**What this PR does / why we need it**:
This PR brings in additional support and validation for providing FQDN instead of IP address.

**Which issue(s) this PR fixes**:
<!--
*Please provide the issues number or link.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #133 

**Test Report Added?**:
/kind TESTED


**Test Report**:
**1. Test Results for Live k8s cluster** 

_Tested with CSI version 2.3.0_

```
bin/vdoctl deploy --spec https://github.com/vmware-tanzu/vsphere-kubernetes-drivers-operator/releases/download/0.1.1/vdo-spec-vanilla-k8s.yaml
Tip: now that you have deployed VDO, you might want to try 'vdoctl configure drivers' to configure vsphere drivers

bin/vdoctl configure drivers
Do you want to configure CloudProvider? (Y/N) y
Please provide the vcenter IP/FQDN for configuring CloudProvider 
VC IP/FQDN sc2-10-187-159-221.nimbus.eng.vmware.com
Do you want to establish a secure connection? (Y/N) n
Please provide the credentials for configuring CloudProvider
Username administrator@vsphere.local
Password ********
Datacenter(s) Datacenter

```
```
kubectl get pods -A
kube-system         vsphere-cloud-controller-manager-nmr7n    1/1     Running   0          16s
vmware-system-csi   vsphere-csi-controller-8489c5b7f8-gm7p8   6/6     Running   0          13s
vmware-system-csi   vsphere-csi-node-69wsn                    3/3     Running   0          13s
vmware-system-csi   vsphere-csi-node-k2wlj                    3/3     Running   0          13s
vmware-system-vdo   vdo-controller-manager-5d749b8fc4-2n6pr   2/2     Running   0          11m

```
```
bin/vdoctl status
CloudProvider   : Configured
         vCenter : 
                sc2-10-187-159-221.nimbus.eng.vmware.com  (Credentials Verified)
         Nodes : 
                 master-vm : ready 
                 worker-vm : ready 
StorageProvider : Deployed
         vCenter : 
                sc2-10-187-159-221.nimbus.eng.vmware.com  (Credentials Verified)

```
**2. Test Results for KIND cluster**

_Tested with CSI version 2.3.0_

```
bin/vdoctl configure drivers
Do you want to configure CloudProvider? (Y/N) y
Please provide the vcenter IP/FQDN for configuring CloudProvider 
VC IP/FQDN sc2-10-185-38-193.eng.vmware.com
Do you want to establish a secure connection? (Y/N) n
Please provide the credentials for configuring CloudProvider
Username administrator@vsphere.local
Password ********
Datacenter(s) Datacenter

```
```
kubectl get pods -A
NAMESPACE            NAME                                         READY   STATUS    RESTARTS   AGE
kube-system          vsphere-cloud-controller-manager-l57qh       1/1     Running   0          117m
vmware-system-csi    vsphere-csi-controller-8489c5b7f8-k2pzg      6/6     Running   0          112m
vmware-system-csi    vsphere-csi-node-98gc6                       3/3     Running   0          112m
vmware-system-vdo    vdo-controller-manager-7f98f4856d-f6v6p      2/2     Running   1          28h

```
```
bin/vdoctl status                                                                        
CloudProvider   : Configured
         vCenter : 
                sc2-10-185-38-193.eng.vmware.com  (Credentials Verified)
         Nodes : 
                 kind-control-plane : ready 
StorageProvider : Deployed
         vCenter : 
                sc2-10-185-38-193.eng.vmware.com  (Credentials Verified)

```

**Special notes for your reviewer**:
